### PR TITLE
Fix/preview mode removes line breaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/node_modules
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /node_modules
+/target
 

--- a/client/resources/public/wh.css
+++ b/client/resources/public/wh.css
@@ -9344,6 +9344,8 @@ a.navbar-item,
     border: solid 1px #6E7F89;
     /* &:focus, &:focus-within, &:hover */
     /*   @include hover-focus-state */ }
+    .contribute__body .textarea p {
+      margin-bottom: 1.5em; }
 
 .contribute__body__controls {
   display: flex;

--- a/client/styles/_contribute.sass
+++ b/client/styles/_contribute.sass
@@ -29,6 +29,8 @@
     border: solid 1px $steel-gray
     /* &:focus, &:focus-within, &:hover */
     /*   @include hover-focus-state */
+    p
+      margin-bottom: 1.5em
 .contribute__body__controls
   display: flex
   justify-content: space-between


### PR DESCRIPTION
Fixes #11 

It appears the markdown renderer ignores single line breaks, while double line breaks generate `p` tags. These can be styled to achieve the desired visual effect. 

Ignoring the single line break allows the user to wrap their lines in narrow columns. 

See screenshots for edit / preview. Note the narrow column on the first two paragraphs and the newly styled result.

This solution implies elements other than paragraphs should have some styling to look good in the preview (a more comprehensive markdown test reveals styles are missing for pretty much all the resulting html tags). Let me know in your comments if I should proceed with such changes.

EDIT TAB:
![Screenshot from 2019-09-27 23-46-06](https://user-images.githubusercontent.com/1617798/65804127-1e7c3c80-e181-11e9-9fca-961a0b6535eb.png)

PREVIEW TAB
![Screenshot from 2019-09-27 23-46-23](https://user-images.githubusercontent.com/1617798/65804126-1e7c3c80-e181-11e9-84d7-d014d3ee1da4.png)



