### PR TITLE
Edit career history

### DIFF
--- a/client/src/wh/logged_in/profile/events.cljs
+++ b/client/src/wh/logged_in/profile/events.cljs
@@ -363,7 +363,7 @@
                              (s/valid? ::specs/url cv-link))]
       (cond
         ;; sub handles the case when a link is nil, and won't show it in the views
-        (or valid-cv-link? "")
+        (or valid-cv-link? (empty? cv-link))
         {:db       db
          :graphql  {:query      graphql/update-user-mutation--approval
                     :variables  {:update_user (graphql-cv-update db)}

--- a/client/src/wh/logged_in/profile/subs.cljs
+++ b/client/src/wh/logged_in/profile/subs.cljs
@@ -319,6 +319,19 @@
   :<- [::cv-data]
   (fn [cv _]
     (:cv-link cv)))
+    
+(reg-sub
+ ::cv-file-uploaded?
+ :<- [::profile]
+ (fn [profile]
+   (let [clear-map {:type nil :name "none" :url "http://"}]
+     (not= clear-map (get-in profile [::profile/cv :file])))))
+
+(reg-sub
+ ::cv-link-uploaded?
+ :<- [::profile]
+ (fn [profile]
+   (not (empty? (get-in profile [::profile/cv :link])))))    
 
 (reg-sub
   ::error-message

--- a/client/src/wh/logged_in/profile/views.cljs
+++ b/client/src/wh/logged_in/profile/views.cljs
@@ -231,7 +231,7 @@
    [:section.profile-section.cv
     [:div.cv__view
      [:h2 "Career History"]
-     [:p "You can upload a maximu of one cv file and one external cv link."]
+     [:p "You can upload a maximum of one cv file and one external cv link."]
      [error-box]
      (when (<sub [::subs/cv-file-uploaded?])
        [:div (if (owner? user-type) "You uploaded " "Uploaded CV: ")

--- a/client/src/wh/logged_in/profile/views.cljs
+++ b/client/src/wh/logged_in/profile/views.cljs
@@ -239,6 +239,7 @@
          [:a.a--underlined {:href cv-url, :target "_blank" :rel "noopener"}
           (if (owner? user-type)
             cv-filename
+
             "Click here to download")]
          (when (owner? user-type)
            [icon "close"
@@ -260,11 +261,8 @@
        (if (owner? user-type)
          "You haven't uploaded resume yet."
          "No uploaded resume yet."))]
-     (when (owner-or-admin? user-type)
-       [:div.cv__buttons
-        (if (<sub [::subs/cv-uploading?])
-          [:button.button {:disabled true} "Uploading..."]
-          [cv-section-buttons])])]))
+    (when (owner-or-admin? user-type)
+      [cv-section-buttons])]))
 
 ;; Private section – view
 

--- a/client/src/wh/logged_in/profile/views.cljs
+++ b/client/src/wh/logged_in/profile/views.cljs
@@ -264,7 +264,7 @@
        [:div.cv__buttons
         (if (<sub [::subs/cv-uploading?])
           [:button.button {:disabled true} "Uploading..."]
-          [cv-section-buttons)])]])
+          [cv-section-buttons])])]))
 
 ;; Private section – view
 

--- a/client/src/wh/logged_in/profile/views.cljs
+++ b/client/src/wh/logged_in/profile/views.cljs
@@ -263,6 +263,7 @@
      (when (owner-or-admin? user-type)
        [:div.cv__buttons
         (if (<sub [::subs/cv-uploading?])
+          [:button.button {:disabled true} "Uploading..."]
           [cv-section-buttons)])]])
 
 ;; Private section – view

--- a/client/styles/_profile.sass
+++ b/client/styles/_profile.sass
@@ -182,6 +182,17 @@ $avatar-size-mobile: 60px
         align-items: center
     .button
       margin: 10px
+    .cv__wrapper
+      display: inline-flex
+      .cv-link__icon
+        width: 24px
+        height: 24px
+        margin-left: 10px
+        fill: #dedede
+        cursor: pointer;
+        transition: fill .2s
+        &:hover
+          fill: darken(#dedede, 25%)
 
 .profile-section__applications__job
   border-bottom: 1px solid $pale-gray

--- a/client/styles/_profile.sass
+++ b/client/styles/_profile.sass
@@ -189,7 +189,7 @@ $avatar-size-mobile: 60px
         height: 24px
         margin-left: 10px
         fill: #dedede
-        cursor: pointer;
+        cursor: pointer
         transition: fill .2s
         &:hover
           fill: darken(#dedede, 25%)


### PR DESCRIPTION
#20 

In order to allow the user to remove and add their cv files and/or links, I went for the simple overriding solution, which uses pre-existing functionality and graphql queries , just with empty values. Spec checks are preserved though , and the UI will not show empty strings as the subs handle that.

For a complete walkthrough on the development of the fixes in regards to this issue, the gist covering it all is just [here](https://gist.github.com/Alex-Bakic/e23824a92f8bb18adf8fc63a6e283da2)