### PR TITLE
Improve error messages on image upload failures

### DIFF
--- a/client/src/wh/company/create_job/events.cljs
+++ b/client/src/wh/company/create_job/events.cljs
@@ -6,6 +6,7 @@
     [clojure.string :as str]
     [re-frame.core :refer [path reg-event-db reg-event-fx]]
     [wh.common.cases :as cases]
+    [wh.common.errors :as common-errors]
     [wh.common.data :as data :refer [get-manager-email get-manager-name]]
     [wh.common.fx.google-maps :as google-maps]
     [wh.common.location :as location]
@@ -668,11 +669,12 @@
                ::create-job/logo-uploading? false)
              (update ::create-job/form-errors (fnil disj #{}) :wh.company.profile/logo))}))
 
-(reg-event-db
+(reg-event-fx
   ::logo-upload-failure
   create-job-interceptors
-  (fn [db _]
-    (assoc db ::create-job/logo-uploading? false)))
+  (fn [{db :db} [resp]]
+    {:db (assoc db ::create-job/logo-uploading? false)
+     :dispatch [:error/set-global (common-errors/image-upload-error-message (:status resp))]}))
 
 (reg-event-db
   ::set-benefits-search

--- a/client/src/wh/company/edit/events.cljs
+++ b/client/src/wh/company/edit/events.cljs
@@ -10,6 +10,7 @@
     [goog.Uri :as uri]
     [re-frame.core :refer [path reg-event-db reg-event-fx]]
     [wh.common.cases :as cases]
+    [wh.common.errors :as errors]
     [wh.common.data :refer [get-manager-email get-manager-name]]
     [wh.common.logo]
     [wh.common.upload :as upload]
@@ -120,11 +121,12 @@
                 ::edit/logo-uploading? false)
      :dispatch [::check ::edit/logo]}))
 
-(reg-event-db
+(reg-event-fx
   ::logo-upload-failure
   company-interceptors
-  (fn [{db :db} _]
-    (assoc db ::edit/logo-uploading? false)))
+  (fn [{db :db} [resp]]
+    {:db (assoc db ::edit/logo-uploading? false)
+     :dispatch [:error/set-global (errors/image-upload-error-message (:status resp))]}))
 
 (defn naive-diff
   "A top-level comparison of key values across two maps. First arg should be the one you expect to have changed.

--- a/client/src/wh/logged_in/profile/events.cljs
+++ b/client/src/wh/logged_in/profile/events.cljs
@@ -4,6 +4,7 @@
     [clojure.string :as str]
     [re-frame.core :refer [dispatch path reg-event-db reg-event-fx]]
     [wh.common.cases :as cases]
+    [wh.common.errors :as errors]
     [wh.common.data :as data]
     [wh.common.graphql-queries :as graphql]
     [wh.common.specs.primitives :as specs]
@@ -484,9 +485,9 @@
 (reg-event-fx
   ::avatar-upload-failure
   profile-interceptors
-  (fn [{db :db} _]
+  (fn [{db :db} [resp]]
     {:db       (assoc db ::profile/avatar-uploading? false)
-     :dispatch [::pages/set-error "There was an error uploading your avatar."]}))
+     :dispatch [:error/set-global (errors/image-upload-error-message (:status resp))]}))
 
 (reg-event-fx
  ::cover-letter-upload

--- a/common-pages/src/wh/company/profile/events.cljc
+++ b/common-pages/src/wh/company/profile/events.cljc
@@ -105,9 +105,9 @@
 (reg-event-fx
   ::photo-upload-failure
   profile-interceptors
-  (fn [{db :db} _]
+  (fn [{db :db} [resp]]
     {:db (assoc db ::profile/photo-uploading? false)
-     :dispatch [:error/set-global "There was an error adding the photo"]}))
+     :dispatch [:error/set-global (errors/image-upload-error-message (:status resp))]}))
 
 (reg-event-fx
   ::add-photo
@@ -450,11 +450,12 @@
   (fn [db _]
     (dissoc db ::profile/pending-logo)))
 
-(reg-event-db
+(reg-event-fx
   ::logo-upload-failure
   profile-interceptors
-  (fn [{db :db} _]
-    (assoc db ::profile/logo-uploading? false)))
+  (fn [{db :db} [resp]]
+    {:db (assoc db ::profile/logo-uploading? false)
+     :dispatch [:error/set-global (errors/image-upload-error-message (:status resp))]}))
 
 (reg-event-db
  ::remove-pending-location

--- a/common/src/wh/common/errors.cljc
+++ b/common/src/wh/common/errors.cljc
@@ -21,3 +21,11 @@
 
 (defn get-blog-error-message [error-key]
   (get error-map-blog error-key (:default error-map-blog)))
+
+(defn image-upload-error-message
+  "Generate a message to display to the user based on `status-code`."
+  [status-code]
+  (cond
+    (= status-code 413) "Selected image is too large."
+    (= status-code 415) "Selected file's media type is not supported."
+    :else "There was an error uploading your image."))


### PR DESCRIPTION
This PR adds addresses issue #35 

In this PR I made all of the image uploading events also dispatch to the global error.  I added the function `image-upload-error-message` in common/errors.cljs to return an appropriate message for the status code. I was able to pin down the 413 case (too large) and 415 case (type not supported) but let me know if I should include cases for more status codes.

By the way, the contributing experience was really nice for this project 🙂