### PR TITLE
Add dark mode

### DIFF
--- a/client/src/wh/core.cljs
+++ b/client/src/wh/core.cljs
@@ -21,6 +21,7 @@
                   (.getElementById js/document "app")))
 
 (defn ^:export init []
+  (pages/load-default-style!)
   (pages/hook-browser-navigation!)
   (mount-root))
 

--- a/client/src/wh/logged_in/profile/db.cljs
+++ b/client/src/wh/logged_in/profile/db.cljs
@@ -2,7 +2,8 @@
   (:require [cljs.spec.alpha :as s]
             [clojure.string :as str]
             [wh.common.cases :as cases]
-            [wh.util :as util]))
+            [wh.util :as util]
+            [wh.pages.util :refer [get-main-style]]))
 
 (s/def ::predefined-avatar integer?)
 (s/def ::custom-avatar-mode boolean?)
@@ -20,7 +21,8 @@
 (def default-db {::editing nil
                  ::predefined-avatar 1
                  ::custom-avatar-mode false
-                 ::location-suggestions {}})
+                 ::location-suggestions {}
+                 ::darkmode-enabled? (= :dark (get-main-style))})
 
 (defn ->sub-db [data]
   (into {}

--- a/client/src/wh/logged_in/profile/db.cljs
+++ b/client/src/wh/logged_in/profile/db.cljs
@@ -8,6 +8,7 @@
 (s/def ::predefined-avatar integer?)
 (s/def ::custom-avatar-mode boolean?)
 (s/def ::editing (s/nilable keyword?))
+(s/def ::darkmode-enabled? boolean?)
 (s/def ::contributions (s/* (s/keys :req-un [::id ::title]
                                     :opt-un [::published])))
 ;; FIXME: This spec is wrong (:wh/location specs unnamespaced keys and
@@ -15,7 +16,7 @@
 ;; location spec between client and server.
 ;; (s/def ::location-suggestions (s/map-of integer? (s/nilable (s/coll-of :wh/location))))
 
-(s/def ::sub-db (s/keys :req [::editing ::predefined-avatar ::custom-avatar-mode]
+(s/def ::sub-db (s/keys :req [::editing ::predefined-avatar ::custom-avatar-mode ::darkmode-enabled?]
                         :opt [::contributions]))
 
 (def default-db {::editing nil

--- a/client/src/wh/logged_in/profile/events.cljs
+++ b/client/src/wh/logged_in/profile/events.cljs
@@ -17,7 +17,8 @@
     [wh.logged-in.profile.location-events :as location-events]
     [wh.pages.core :refer [on-page-load] :as pages]
     [wh.user.db :as user]
-    [wh.util :as util])
+    [wh.util :as util]
+    [wh.pages.util :refer [set-main-style!]])
   (:require-macros [clojure.core.strint :refer [<<]]))
 
 (def profile-interceptors (into db/default-interceptors
@@ -655,3 +656,10 @@
                    :on-failure [::removal-failure]}
       :dispatch-n [[::pages/set-loader]
                    [:error/close-global]]})))
+
+(reg-event-db
+ ::toggle-dark-mode
+  profile-interceptors
+ (fn [db [state]]
+   (set-main-style! (if state :dark :light))
+   (assoc db ::profile/darkmode-enabled? state)))

--- a/client/src/wh/logged_in/profile/subs.cljs
+++ b/client/src/wh/logged_in/profile/subs.cljs
@@ -343,3 +343,9 @@
       (condp = field
         :email "Please enter a valid email address."
         "This field is incorrect."))))
+
+(reg-sub
+ ::darkmode-enabled?
+ :<- [::profile]
+ (fn [profile _]
+   (::profile/darkmode-enabled? profile)))

--- a/client/src/wh/logged_in/profile/views.cljs
+++ b/client/src/wh/logged_in/profile/views.cljs
@@ -332,6 +332,18 @@
     (when (:current-location fields)    [view-field "Current location:" (or current-location "None")])
     (when (:preferred-locations fields) [view-field "Preferred locations:" (itemize preferred-locations :no-data-message "No locations selected.")])]))
 
+(defn settings-view []
+  (let [dark-mode (<sub [::subs/darkmode-enabled?])]
+    [:section.profile-section.settings
+     [:h2 "Settings"]
+     [:div {:class "field"}
+      [:input.toggle {:type "checkbox"
+                      :id "dark-mode-toggle"
+                      :class "switch is-rtl"
+                      :checked dark-mode
+                      :on-change  #(dispatch [::events/toggle-dark-mode (not dark-mode)])}]      
+      [:label {:for "dark-mode-toggle"} "Toggle Dark Mode"]]]))
+
 ;; Private section – edit
 
 (defn current-location-field []
@@ -444,13 +456,16 @@
 (defn main-view []
   [:div
    (if (<sub [:user/company?])
-     [company-user-view (<sub [::subs/company-data])]
+     [:div
+      [company-user-view (<sub [::subs/company-data])]
+      [settings-view]]
      [:div
       [header-view :owner (<sub [::subs/header-data])]
       [error-box]
       [cv-section-view (<sub [::subs/cv-data])]
       [cover-letter-section-view (<sub [::subs/cover-letter-data])]
-      [private-section-view (<sub [::subs/private-data])]])
+      [private-section-view (<sub [::subs/private-data])]
+      [settings-view]])
 
    [:a.button
     {:data-pushy-ignore "true"

--- a/client/src/wh/pages/core.cljs
+++ b/client/src/wh/pages/core.cljs
@@ -8,6 +8,7 @@
             [re-frame.core :refer [reg-fx reg-sub reg-event-db reg-event-fx dispatch dispatch-sync]]
             [re-frame.db :refer [app-db]]
             [wh.db :as db]
+            [wh.pages.util :refer [get-main-style set-main-style!]]
             [wh.pages.modules :as modules]
             [wh.routes :as routes]
             [wh.verticals :as verticals]))
@@ -251,6 +252,9 @@
 
 (defn hook-browser-navigation! []
   (pushy/start! pushy-instance))
+
+(defn load-default-style! []
+  (set-main-style! (get-main-style)))
 
 (reg-event-db
   ::set-loader

--- a/client/src/wh/register/views.cljs
+++ b/client/src/wh/register/views.cljs
@@ -1,6 +1,7 @@
 (ns wh.register.views
   (:require [re-frame.core :refer [dispatch]]
             [wh.components.conversation.views :refer [codi-message]]
+            [wh.pages.util :refer [local-storage-supported?]]
             [wh.register.email :as email]
             [wh.register.events :as events]
             [wh.register.location :as location]
@@ -10,16 +11,6 @@
             [wh.register.test :as test]
             [wh.register.verify :as verify]
             [wh.subs :refer [<sub]]))
-
-;; See https://stackoverflow.com/questions/11214404/how-to-detect-if-browser-supports-html5-local-storage
-(defn local-storage-supported? []
-  (let [item "workshub-test-ls"]
-    (try
-      (js/localStorage.setItem item item)
-      (js/localStorage.removeItem item)
-      true
-      (catch :default _
-        false))))
 
 (defn unsupported-warning []
   [:div

--- a/client/styles/_articles.sass
+++ b/client/styles/_articles.sass
@@ -52,6 +52,6 @@
       box-shadow: 0 0 0 2px $red
 
     .icon
-      fill: $steel-gray
+      fill: $steel-gray-text
       height: 22px
       width: 22px

--- a/client/styles/_banners.sass
+++ b/client/styles/_banners.sass
@@ -1,6 +1,6 @@
 .login-banner
   margin: 0 !important
-  background: white
+  background: $white
   padding: 20px
 
 

--- a/client/styles/_blog.sass
+++ b/client/styles/_blog.sass
@@ -29,7 +29,7 @@ $hero-top: 26px
 
 .tags
   a
-    color: $red
+    color: $tag-text
 
 .link
   color: $red

--- a/client/styles/_blog.sass
+++ b/client/styles/_blog.sass
@@ -39,7 +39,7 @@ $hero-top: 26px
 .blog__content
   position: relative
   z-index: 1
-  background-color: white
+  background-color: $white
   padding: 0 52px
   transform: translateZ(0px)
   transform-origin: 0 0
@@ -234,7 +234,7 @@ $hero-top: 26px
     display: none
 
   .icon
-    fill: white
+    fill: $white
 
     &.share-links__facebook
       width: 37px
@@ -254,7 +254,7 @@ $author-info-padding: 9px
 $author-info-photo-margin: 15px
 
 .author-info
-  background-color: white
+  background-color: $white
   margin-left: 10px
   margin-right: 10px
   margin-top: 20px
@@ -343,7 +343,7 @@ $rocket-red-2: #ff7c6e
   cursor: pointer
   border-radius: 30px
   .icon
-    fill: white
+    fill: $white
     height: auto
     width: 20px
   &:hover
@@ -361,7 +361,7 @@ $counter-size: 24px
   line-height: $counter-size
   text-align: center
   background-color: $red
-  color: white
+  color: $white
   z-index: 1010
   border-radius: $counter-size / 2
 

--- a/client/styles/_bubbles.sass
+++ b/client/styles/_bubbles.sass
@@ -43,7 +43,7 @@ $bubble-radius-hover: 63
   font-weight: $font-semi-bold
   text-transform: uppercase
   text-align: center
-  color: white
+  color: $white
   //border: $bubble-border solid black
   box-shadow: 1px 2px 4px 0 rgba(0, 0, 0, 0.2)
   padding: 0
@@ -64,7 +64,7 @@ $bubble-radius-hover: 63
     animation: $animation-duration increase-like
     @include bubble-diameter($bubble-radius-like + 0px)
     background-color: $metal-blue
-    border: 6px solid $steel-gray
+    border: 6px solid $steel-gray-text
 
   &.base
     animation: $animation-duration increase-unlike

--- a/client/styles/_buttons.sass
+++ b/client/styles/_buttons.sass
@@ -18,12 +18,12 @@ $button-font-size: 11px
   font-weight: $font-semi-bold
   letter-spacing: 0.5px
   line-height: normal
-  color: white
+  color: $white
   // needed for button--loading to work always
   position: relative
   &:hover
     background: $button-hover !important
-    color: white !important
+    color: $white !important
     cursor: pointer
   &:focus
     outline: none
@@ -54,7 +54,7 @@ $button-font-size: 11px
   width: 108px
 
 .button__icon
-  fill: white
+  fill: $white
   vertical-align: middle
   margin-right: 12px
 
@@ -62,7 +62,7 @@ $button-font-size: 11px
   fill: $red
 
 .button__icon--twitter
-  fill: $wh-white
+  fill: $white
 
 .button--light
   background: $light-red
@@ -72,7 +72,7 @@ $button-font-size: 11px
     color: $red !important
 
 .button--inverted
- background: white
+ background: $white
  color: $red
  border: solid 1px $red
  &:hover
@@ -81,17 +81,17 @@ $button-font-size: 11px
 
 .button--green
   background: $metal-blue
-  color: white
+  color: $white
   &:hover
     background: $metal-blue !important
-    color: white !important
+    color: $white !important
 
 .button--grey
   background: $greyish
-  color: white
+  color: $white
   &:hover
     background: $greyish !important
-    color: white !important
+    color: $white !important
 
 .button--loading
   color: transparent !important
@@ -111,9 +111,9 @@ $button-font-size: 11px
 
 .conversation-multi-button
   display: block
-  border: 1px solide $steel-gray
+  border: 1px solide $steel-gray-text
   background: $light-gray
-  color: $steel-gray
+  color: $steel-gray-text
   font-weight: $font-medium
   font-size: $button-font-size
   line-height: 1
@@ -123,13 +123,13 @@ $button-font-size: 11px
   margin-left: auto
 
   &:hover
-    background: white !important
-    color: $steel-gray
+    background: $white !important
+    color: $steel-gray-text
     cursor: pointer
 
 .conversation-multi-button--selected
-  background: $steel-gray
-  color: white
+  background: $steel-gray-text
+  color: $white
   &:hover
     background: $dark-gray !important
 
@@ -154,36 +154,36 @@ $button-font-size: 11px
   font-size: 14px
 
 .button--disabled
-  background-color: white
+  background-color: $white
   color: $greyish
   border: solid 1px $greyish
   &:hover
-    background: white !important
+    background: $white !important
     color: $greyish !important
     cursor: pointer !important
 
 .button--stackoverflow
-  background-color: $wh-white !important
+  background-color: $white !important
   color: $wh-black !important
   box-shadow: 0 0 0 1px $stackoverflow-grey
   &:hover
-    background-color: $wh-white !important
+    background-color: $white !important
     color: $wh-black !important
     box-shadow: 0 0 0 1px $wh-black
 
 .button--twitter
   background-color: $twitter-blue !important
-  color: $wh-white !important
+  color: $white !important
   &:hover
     background-color: $twitter-blue-hover !important
-    color: $wh-white !important
+    color: $white !important
 
 .button--connect
   height: auto
   padding: 6px 12px
 
 .remove-text-field-btn
-  fill: white
+  fill: $white
   background: $red
   border-radius: 10px
   cursor: pointer

--- a/client/styles/_candidates.sass
+++ b/client/styles/_candidates.sass
@@ -1,5 +1,5 @@
 .candidates-header
-  background-color: white
+  background-color: $white
   padding: 10px
   margin-bottom: 10px !important
 
@@ -12,7 +12,7 @@
     margin-right: 20px
 
 .candidate-pod
-  background-color: white
+  background-color: $white
   display: flex
   margin-bottom: 10px
   padding: 15px
@@ -84,7 +84,7 @@
 
 .candidate-pod__loader
   height: 70vh
-  background-color: white
+  background-color: $white
   display: flex
 
 .create-candidate__upload-cta, .create-candidate__add-link, .create-candidate__uploaded-file
@@ -92,14 +92,14 @@
   font-size: 12px
   line-height: 18px
   font-weight: $font-medium
-  color: $steel-gray
+  color: $steel-gray-text
   .icon
     display: inline-block
     vertical-align: middle
     width: 18px
     height: 18px
     margin-right: 9px
-    fill: $steel-gray
+    fill: $steel-gray-text
 
 .create-candidate__uploaded-file .icon
   fill: $red

--- a/client/styles/_cards.sass
+++ b/client/styles/_cards.sass
@@ -8,14 +8,14 @@ $card-job-padding: 11px
   min-width: $min-card-width
   display: inline-block
   text-align: left
-  background: white
+  background: $white
   position: relative
 
 .card__label
   padding: 6px
   border-radius: 2px
   text-transform: uppercase
-  border: 1px solid $steel-gray
+  border: 1px solid $steel-gray-text
   height: 30px
   line-height: 30px
   align-items: center
@@ -40,7 +40,7 @@ $card-job-padding: 11px
 .card__label--unpublished
   background-color: $light-orange
   border: none
-  color: white
+  color: $white
   position: absolute
   top: -1px
   right: -1px
@@ -272,7 +272,7 @@ $card-job-padding: 11px
     .logo--empty
       height: 48px
       width: 48px
-      border: 1px solid $steel-gray
+      border: 1px solid $steel-gray-text
     img
       height: 48px
       object-fit: contain
@@ -324,7 +324,7 @@ $card-job-padding: 11px
         left: 0
         width: 100%
         height: 100%
-        background: white
+        background: $white
         display: flex
         justify-content: center
         align-items: center
@@ -365,7 +365,7 @@ $card-job-padding: 11px
   .salary
     margin-bottom: 11px
     font-weight: 600
-    color: $steel-gray
+    color: $steel-gray-text
   .tagline
     .tagline-content
       margin-bottom: 11px

--- a/client/styles/_cards.sass
+++ b/client/styles/_cards.sass
@@ -8,7 +8,7 @@ $card-job-padding: 11px
   min-width: $min-card-width
   display: inline-block
   text-align: left
-  background: $white
+  background: $section-white
   position: relative
 
 .card__label

--- a/client/styles/_chatbot.sass
+++ b/client/styles/_chatbot.sass
@@ -27,11 +27,11 @@
     fill: #dbdbdb
     &:hover
       cursor: pointer
-      fill: $steel-gray
+      fill: $steel-gray-text
 
 .chatbot--loading
   z-index: 100
-  background: white
+  background: $white
 
   div[class*="loader-"]
     margin-top: 150px
@@ -60,7 +60,7 @@
   .file-label
     &:hover
       .file-cta
-        color: white !important
+        color: $white !important
         background: $steel-gray !important
 
 .add-full-name, .add-visa

--- a/client/styles/_companies.sass
+++ b/client/styles/_companies.sass
@@ -55,7 +55,7 @@
 
 
 .companies__company
-  background: $white
+  background: $section-white
   padding: 3.5%
   display: flex
   position: relative

--- a/client/styles/_companies.sass
+++ b/client/styles/_companies.sass
@@ -55,7 +55,7 @@
 
 
 .companies__company
-  background: white
+  background: $white
   padding: 3.5%
   display: flex
   position: relative
@@ -144,7 +144,7 @@ $cc-desc-lines-to-show-mobile: 3
 
 .companies__side
   &>section
-    background-color: white
+    background-color: $white
 
 .company-jobs__list
   display: flex
@@ -182,7 +182,7 @@ $cc-desc-lines-to-show-mobile: 3
       margin-right: 16px
 
 .companies__sorting
-  color: $steel-gray
+  color: $steel-gray-text
   display: flex
   flex-direction: row
   align-items: center

--- a/client/styles/_company.sass
+++ b/client/styles/_company.sass
@@ -27,7 +27,7 @@
   color: $greyish
   .company-signup__steps--current,
   .payment-setup__steps--current
-    color: $steel-gray
+    color: $steel-gray-text
   span
     margin: 0px 10px
 
@@ -72,7 +72,7 @@
 .company-signup__content
   form
     label
-      color: $steel-gray
+      color: $steel-gray-text
       line-height: 18px
       margin-bottom: 18px
 
@@ -163,7 +163,7 @@
   line-height: 20px
   strong
     font-weight: $font-semi-bold
-    color: $steel-gray
+    color: $steel-gray-text
 
 
 $company-card-padding: 18px
@@ -316,7 +316,7 @@ $column-gap: 1.5rem
       content: 'Upgrade/View'
 
 .your-company__package-name
-  color: $steel-gray
+  color: $steel-gray-text
   font-size: 14px
   line-height: 14px
   font-weight: $font-semi-bold
@@ -414,13 +414,13 @@ $description-height: 300px
 .company-edit__user-header
   margin: 12px 0
   th
-    color: $steel-gray
+    color: $steel-gray-text
     font-weight: $font-regular
     font-size: 12px
 
 .company-edit__user
   td
-    color: $steel-gray
+    color: $steel-gray-text
     font-weight: $font-semi-bold
     font-size: 14px
 
@@ -445,7 +445,7 @@ $description-height: 300px
   svg
     margin-right: 5px
     margin-top: 6px
-    fill: white
+    fill: $white
     background: $red
     border-radius: 10px
     cursor: pointer
@@ -466,8 +466,6 @@ $description-height: 300px
   margin-top: 0 !important
   margin-right: 10px
   height: 40px
-  &.company-edit__github-integration
-    max-width: 140px
   +mobile
     margin-right: 3px
   img
@@ -518,7 +516,7 @@ $description-height: 300px
     padding: 18px
     margin: auto 0
     width: 320px
-    background: white
+    background: $white
     border-radius: 5px
     box-shadow: 2px 2px 4px 0 rgba(0, 0, 0, 0.3)
     p
@@ -541,19 +539,19 @@ $description-height: 300px
     margin-top: 5px
 
 .activity__container
-  background: white
+  background: $white
   height: 100%
-  color: $steel-gray
+  color: $steel-gray-text
   padding: 18px
   line-height: 18px
   strong
-    color: $steel-gray
+    color: $steel-gray-text
     font-weight: $font-semi-bold
 
 .activity__item
   display: flex
   .icon
-    fill: $steel-gray
+    fill: $steel-gray-text
     &.like
       width: 24px
       height: 24px
@@ -621,7 +619,7 @@ $description-height: 300px
   margin-bottom: 1px
 
 .company-job__stat-number
-  color: $steel-gray
+  color: $steel-gray-text
   font-size: 11px
   line-height: 18px
   text-align: center
@@ -632,10 +630,10 @@ $description-height: 300px
     color: $red
 
 .company-job__thats-you
-  color: $steel-gray
+  color: $steel-gray-text
 
 .company-job__posted
-  color: $steel-gray
+  color: $steel-gray-text
   font-weight: $font-medium
   margin-top: 12px
   font-size: 9px
@@ -757,7 +755,7 @@ $description-height: 300px
   line-height: 1.6em
 
 .company-application__applied-on
-  color: $steel-gray
+  color: $steel-gray-text
   font-size: 9px
   line-height: 18px
   height: 18px
@@ -790,7 +788,7 @@ $description-height: 300px
   .icon
     width: 16px
     height: 16px
-    fill: $steel-gray
+    fill: $steel-gray-text
     &.job-location
       width: 24px
       height: 24px
@@ -850,7 +848,7 @@ $description-height: 300px
     opacity: 0.4
 
 .company-application__job
-  background-color: white
+  background-color: $white
   display: grid
   padding: 18px
   grid-template-columns: 75px 1fr 108px
@@ -894,7 +892,7 @@ $description-height: 300px
   font-size: 9px
   font-weight: $font-medium
   letter-spacing: 0.9px
-  color: $steel-gray
+  color: $steel-gray-text
   +mobile
     display: none
 
@@ -902,7 +900,7 @@ $description-height: 300px
   grid-area: 1 / 3 / 4 / 4
   display: flex
   fill: $steel-gray
-  color: $steel-gray
+  color: $steel-gray-text
   +mobile
     display: none
 
@@ -928,7 +926,7 @@ $description-height: 300px
 
 .company-applications__tabs-spacer
   height: 40px
-  background-color: white
+  background-color: $white
   width: 100%
   margin-bottom: 18px
   border-bottom: 3px solid $skeleton-background-color
@@ -992,7 +990,7 @@ $description-height: 300px
 .company-application__notes
   white-space: pre-wrap
   margin-top: 16px
-  color: $steel-gray
+  color: $steel-gray-text
   svg
     margin-right: 8px
   &>div
@@ -1019,13 +1017,13 @@ $description-height: 300px
   &>div
     p
       line-height: 22px
-      color: $steel-gray
+      color: $steel-gray-text
       margin-bottom: 20px
       font-size: 14px
     h1
       padding: 0 0 16px 0
       margin: 0
-      color: $steel-gray
+      color: $steel-gray-text
 
 .company-applications__popup--job-selection
   .job-selection__jobs
@@ -1175,7 +1173,7 @@ $description-height: 300px
     span
       white-space: nowrap
       line-height: 15px
-      color: $steel-gray
+      color: $steel-gray-text
       &:nth-child(odd)
         font-weight: $font-medium
         font-size: 9px
@@ -1194,7 +1192,7 @@ $description-height: 300px
   .counts
     display: flex
     fill: $steel-gray
-    color: $steel-gray
+    color: $steel-gray-text
   .count
     display: flex
     flex-direction: column
@@ -1238,7 +1236,7 @@ $description-height: 300px
     fill: $skeleton-background-color
 
 .company-edit__payment-details
-  color: $steel-gray
+  color: $steel-gray-text
   +mobile
     margin-bottom: 60px
   .payment__card-form
@@ -1365,9 +1363,9 @@ $description-height: 300px
         font-weight: $font-semi-bold
         text-decoration: underline
         a
-          color: $steel-gray
+          color: $steel-gray-text
       td
-        color: $steel-gray
+        color: $steel-gray-text
         padding-left: 18px
       tr:not(.is-selected)
         &:nth-child(odd)
@@ -1434,13 +1432,13 @@ $description-height: 300px
   border: 1px solid $red
   background-color: $lighter-red
   padding: 18px
-  color: $steel-gray
+  color: $steel-gray-text
   p
     margin-bottom: 6px
   div, strong
     line-height: 18px
   strong
-    color: $steel-gray
+    color: $steel-gray-text
     display: inline-block
     width: 170px
 
@@ -1461,7 +1459,7 @@ $description-height: 300px
 
 .company-dashboard__profile-banner
   section
-    background-color: white
+    background-color: $white
     padding: 18px
     display: flex
 

--- a/client/styles/_company_onboarding.sass
+++ b/client/styles/_company_onboarding.sass
@@ -48,7 +48,7 @@ $company-onboarding__action-height: 64px
       align-items: center
     .icon
       margin-top: 2px
-      background-color: white
+      background-color: $white
       padding: 5px
       width: 24px
       height: 24px

--- a/client/styles/_company_profile.sass
+++ b/client/styles/_company_profile.sass
@@ -31,12 +31,12 @@ $company-profile-anchor-offset-mobile: $company-profile-sticky-height + $navbar-
     .is-flex
       justify-content: space-between
     .title
-      color: $steel-gray
+      color: $steel-gray-text
       margin: 0px 0px 18px 0px
     .ql-container
       min-height: 300px
     &.company-profile__section--headed
-      background-color: white
+      background-color: $white
       padding: 18px
       .title
         font-size: 18px
@@ -60,14 +60,14 @@ $company-profile-anchor-offset-mobile: $company-profile-sticky-height + $navbar-
   margin-top: 18px
   & > section
     margin: 0px
-    background-color: white
+    background-color: $white
     padding: 18px
   section + section
     margin-top: 18px
 
 .company-profile__toggle
   height: 78px
-  background-color: white
+  background-color: $white
   +desktop
     border: 1px solid $pale-red
     margin-bottom: 18px
@@ -142,7 +142,7 @@ $company-profile-anchor-offset-mobile: $company-profile-sticky-height + $navbar-
   font-size: 11px
   font-weight: $font-medium
   letter-spacing: 0.92px
-  color: $steel-gray
+  color: $steel-gray-text
   line-height: 1
   +mobile
     padding: 0px 18px 0px 18px
@@ -265,7 +265,7 @@ $company-profile-anchor-offset-mobile: $company-profile-sticky-height + $navbar-
     max-width: unset
 .company-profile__about-us__description
   font-style: italic
-  color: $steel-gray
+  color: $steel-gray-text
   font-size: 18px
   line-height: normal
   +mobile
@@ -393,7 +393,7 @@ $company-profile-anchor-offset-mobile: $company-profile-sticky-height + $navbar-
   h3
     font-size: 14px
     line-height: 18px
-    color: $steel-gray
+    color: $steel-gray-text
   span
     font-size: 12px
     color: $greyish
@@ -417,7 +417,7 @@ $company-profile-anchor-offset-mobile: $company-profile-sticky-height + $navbar-
     cursor: pointer
     width: 24px
     height: 24px
-    fill: $steel-gray
+    fill: $steel-gray-text
     transition: transform 0.2s
     transform: rotate(0deg)
 
@@ -475,18 +475,18 @@ $company-profile-anchor-offset-mobile: $company-profile-sticky-height + $navbar-
   padding: 6px
   text-align: left
   background-color: $lighter-gray
-  color: $steel-gray
+  color: $steel-gray-text
   margin-top: -12px
   margin-bottom: 12px
   li
     line-height: 1
     display: flex
     align-items: center
-    color: $steel-gray
+    color: $steel-gray-text
     height: 18px
     margin: 18px 0
     .icon
-      fill: $steel-gray
+      fill: $steel-gray-text
       flex-shrink: 0
       margin-right: 12px
     .icon--close
@@ -502,7 +502,7 @@ $company-profile-anchor-offset-mobile: $company-profile-sticky-height + $navbar-
     color: $red
 
 .company-profile__stats
-  background-color: white
+  background-color: $white
   +desktop
     margin-top: 20px !important
 
@@ -581,7 +581,7 @@ $company-profile-anchor-offset-mobile: $company-profile-sticky-height + $navbar-
 .company-profile__tech-scale__scale-labels
   display: flex
   justify-content: space-between
-  color: $steel-gray
+  color: $steel-gray-text
   line-height: 1
   +mobile
     font-size: 11px
@@ -677,7 +677,7 @@ $company-profile-anchor-offset-mobile: $company-profile-sticky-height + $navbar-
   margin-top: 0 !important
 
 .company-profile__banner-cta
-  background-color: white
+  background-color: $white
   display: flex
   flex-wrap: wrap
   padding: 0px 18px 24px 18px
@@ -702,7 +702,7 @@ $company-profile-anchor-offset-mobile: $company-profile-sticky-height + $navbar-
     padding-left: 12px
 
 .company-profile__create-profile-carousel
-  background-color: white
+  background-color: $white
   padding: 48px
   +desktop
     height: 312px
@@ -780,7 +780,7 @@ $company-profile-anchor-offset-mobile: $company-profile-sticky-height + $navbar-
   .icon
     width: 24px
     height: 24px
-    fill: $steel-gray
+    fill: $steel-gray-text
 
 .company-profile__github-details__owner
   display: flex

--- a/client/styles/_contribute.sass
+++ b/client/styles/_contribute.sass
@@ -33,12 +33,12 @@
     height: 100%
     min-height: 400px
     overflow-y: scroll
-    border: solid 1px $steel-gray
+    border: solid 1px $steel-gray-text
   .contribute__textarea
     min-height: 400px
     overflow-y: scroll
-    border: solid 1px $steel-gray
-    background-color: white
+    border: solid 1px $steel-gray-text
+    background-color: $white
     padding: 12px
     max-height: 600px
 .contribute__body__controls
@@ -57,10 +57,10 @@
     +mobile
       width: auto
     &:hover
-      border: solid 1px $steel-gray
+      border: solid 1px $steel-gray-text
   .tab--active
-    background-color: white
-    border: solid 1px $steel-gray
+    background-color: $white
+    border: solid 1px $steel-gray-text
     border-bottom: 0
     position: relative
     &:hover
@@ -97,7 +97,7 @@
   .conversation-element
     line-height: 20px
   strong
-    color: $steel-gray
+    color: $steel-gray-text
 
 .contribute__codi
   opacity: 1
@@ -108,7 +108,7 @@
 .contribute__checklist,
 .contribute__saved
   border: 2px solid $red
-  background-color: white
+  background-color: $white
   padding: 20px 14px
   font-style: italic
   line-height: 1.5em
@@ -116,7 +116,7 @@
     margin: 10px 0px
   strong
     margin: 0
-    color: $steel-gray
+    color: $steel-gray-text
 
 .contribute__saved
   margin-bottom: 18px

--- a/client/styles/_contribute.sass
+++ b/client/styles/_contribute.sass
@@ -59,7 +59,7 @@
     &:hover
       border: solid 1px $steel-gray-text
   .tab--active
-    background-color: $white
+    background-color: $section-white
     border: solid 1px $steel-gray-text
     border-bottom: 0
     position: relative

--- a/client/styles/_dashboard.sass
+++ b/client/styles/_dashboard.sass
@@ -9,13 +9,13 @@
 
   .preferences
     position: relative
-    background: white
+    background: $white
     height: 74px
     min-width: calc(3 * #{$min-card-width} + 4 * #{$column-gap})
     font-size: 12px
     line-height: 74px
     font-weight: $font-semi-bold
-    color: $steel-gray
+    color: $steel-gray-text
     padding-left: 18px
     overflow: hidden
 
@@ -28,7 +28,7 @@
       right: 16px
       top: 0px
       padding-left: 50px
-      background: linear-gradient(to right, rgba(255, 255, 255, 0), white 30px)
+      background: linear-gradient(to right, rgba(255, 255, 255, 0), $white 30px)
 
 .dashboard__jobs
   .column

--- a/client/styles/_dropdown.sass
+++ b/client/styles/_dropdown.sass
@@ -23,4 +23,4 @@ $dropdown-width: 270px
       padding-left: 20px
     &:hover
       background-color: $metal-blue
-      color: white
+      color: $white

--- a/client/styles/_error.sass
+++ b/client/styles/_error.sass
@@ -6,9 +6,9 @@
   +mobile
     width: 100%
   height: 48px
-  color:  white
+  color:  $white
   svg.tick
-    fill: white
+    fill: $white
     height: 12px
     +desktop
       margin-right: 6px
@@ -19,7 +19,7 @@
       float: left
       margin-left: 18px
   svg.close
-    fill: white
+    fill: $white
     margin-top: 7px
     margin-right: 18px
   &.error

--- a/client/styles/_faq.sass
+++ b/client/styles/_faq.sass
@@ -48,7 +48,7 @@
 
 .faq__question__title
   font-family: $family-primary
-  color: $steel-gray
+  color: $steel-gray-text
   font-size: 18px
   font-weight: bold
   line-height: 22px
@@ -57,7 +57,7 @@
     margin-top: -6px
     margin-right: -10px
     margin-left: 10px
-    fill: $steel-gray
+    fill: $steel-gray-text
     min-width: 32px
     min-height: 32px
     transition: transform 0.2s
@@ -91,7 +91,7 @@
 .faq--mini
   .faq__question
     border-top: 1px solid $pale-gray
-    background-color: white
+    background-color: $white
     padding: 8px 0px 0px 0px
     margin-bottom: 6px
     &:last-child
@@ -101,7 +101,7 @@
     font-size: 12px
     font-family: $family-primary
     line-height: 18px
-    color: $steel-gray
+    color: $steel-gray-text
     margin: 6px 0px 12px 0px
     &.collapsed
       max-height: 0px

--- a/client/styles/_footer.sass
+++ b/client/styles/_footer.sass
@@ -6,7 +6,7 @@
   display: flex
   justify-content: space-between
   padding: 60px 40px 20px 40px
-  color: $light-gray-text
+  color: $footer-text
   +mobile
     flex-direction: column
     padding: 44px 18px 20px 18px
@@ -33,7 +33,7 @@
   font-size: 14px
   font-weight: $font-medium
   span a
-    color: $light-gray-text
+    color: $footer-text
   span + span
     margin-left: 10px
 
@@ -46,7 +46,7 @@
 .footer__sitemap
   padding: 35px 40px 20px 40px
   font-size: 12px
-  color: $light-gray-text
+  color: $footer-text
   +mobile
     padding: 0px 18px 20px 18px
     flex-direction: column
@@ -69,7 +69,7 @@
   flex-shrink: 0
   margin-bottom: 20px
   a
-    color: $light-gray-text
+    color: $footer-text
     display: block
     font-weight: $font-semi-bold
     line-height: 24px

--- a/client/styles/_footer.sass
+++ b/client/styles/_footer.sass
@@ -6,7 +6,7 @@
   display: flex
   justify-content: space-between
   padding: 60px 40px 20px 40px
-  color: white
+  color: $light-gray-text
   +mobile
     flex-direction: column
     padding: 44px 18px 20px 18px
@@ -33,7 +33,7 @@
   font-size: 14px
   font-weight: $font-medium
   span a
-    color: white
+    color: $light-gray-text
   span + span
     margin-left: 10px
 
@@ -46,7 +46,7 @@
 .footer__sitemap
   padding: 35px 40px 20px 40px
   font-size: 12px
-  color: white
+  color: $light-gray-text
   +mobile
     padding: 0px 18px 20px 18px
     flex-direction: column
@@ -69,7 +69,7 @@
   flex-shrink: 0
   margin-bottom: 20px
   a
-    color: white
+    color: $light-gray-text
     display: block
     font-weight: $font-semi-bold
     line-height: 24px
@@ -78,15 +78,15 @@
     margin-bottom: 8px
 
 .footer__bottom
-  background: white
-  min-height: 60px
+  background: $light-gray
+  Min-height: 60px
   width: 100%
   padding: 16px 40px 20px 40px
   font-size: 12px
   letter-spacing: 0
-  color: $steel-gray
+  color: $steel-gray-text
   a
-    color: $steel-gray
+    color: $steel-gray-text
   +mobile
     padding: 16px 18px 20px 18px
 
@@ -110,7 +110,7 @@
   .icon
     width: 32px
     height: 32px
-    fill: $steel-gray
+    fill: $steel-gray-text
     &:hover
       transition: all 0.3s ease-in-out
   &.linkedin

--- a/client/styles/_forms.sass
+++ b/client/styles/_forms.sass
@@ -6,7 +6,7 @@ $field-padding: 13px
   border-radius: 0
   box-shadow: none
   font-size: 14px
-  background: white
+  background: $white
   &:focus, &:focus-within
     border-color: $red
     .input__suggestions
@@ -66,7 +66,7 @@ $field-padding: 13px
   .label
     font-size: 16px
     line-height: 18px
-    color: $steel-gray
+    color: $steel-gray-text
     font-weight: $font-semi-bold
     margin-bottom: 10px
     margin-top: 30px
@@ -118,7 +118,7 @@ $field-padding: 13px
   width: 100%
 
 .wh-container
-  background: white
+  background: $white
 
 @mixin checkbox-and-radio
   width: 20px

--- a/client/styles/_formsx.sass
+++ b/client/styles/_formsx.sass
@@ -10,10 +10,10 @@ $logo-dimension: 62px
   border-radius: 0
   box-shadow: none
   font-size: 14px
-  background: white
+  background: $white
   input, textarea, select
-    color: $steel-gray
-    border: solid 1px $steel-gray
+    color: $steel-gray-text
+    border: solid 1px $steel-gray-text
     &:focus, &:focus-within, &:hover
       @include hover-focus-state
 
@@ -38,7 +38,7 @@ $logo-dimension: 62px
 
 .wh-formx
   p
-    color: $steel-gray
+    color: $steel-gray-text
     line-height: 1.5em
   fieldset
     border: none
@@ -47,7 +47,7 @@ $logo-dimension: 62px
       margin-top: 0
   .field
     margin-bottom: 0.75rem
-    color: $steel-gray
+    color: $steel-gray-text
     +mobile
       margin-bottom: 0
     &:last-of-type
@@ -81,7 +81,7 @@ $logo-dimension: 62px
     width: 100%
     line-height: $field-height
     &:after
-      border-color: $steel-gray !important
+      border-color: $steel-gray-text !important
   .text-field-control
     @include form-fieldx
     &:focus-within
@@ -101,7 +101,7 @@ $logo-dimension: 62px
         padding-left: 39px !important
 
     .icon
-      fill: $steel-gray
+      fill: $steel-gray-text
   .text-field-control--removable
     +mobile
       display: flex
@@ -113,7 +113,7 @@ $logo-dimension: 62px
       padding-top: 9px !important /* fixes shift */
 
   .text-field-markdown-preview
-    border: 1px solid $steel-gray
+    border: 1px solid $steel-gray-text
     padding: 12px
   .input, .textarea
     padding: $field-padding
@@ -134,7 +134,7 @@ $logo-dimension: 62px
     font-size: 12px
     line-height: 18px
     font-weight: $font-medium
-    color: $steel-gray
+    color: $steel-gray-text
     margin-bottom: 0px
     &:first-child
       margin-top: 12px
@@ -148,7 +148,7 @@ $logo-dimension: 62px
     font-size: 14px
     position: absolute
     width: 100%
-    background: white
+    background: $white
     z-index: $dropdown-content-z
     padding: 0px 1px 1px 1px
     top: calc(#{$field-height} - 2px) /* overlaps input */
@@ -177,7 +177,7 @@ $logo-dimension: 62px
       width: 100%
       height: calc(100% + #{$field-height})
       bottom: 0
-      box-shadow: 4px 4px 4px $steel-gray
+      box-shadow: 4px 4px 4px $steel-gray-text
       pointer-events: none
   .label__markdown-menu
     display: flex
@@ -207,11 +207,11 @@ $logo-dimension: 62px
   .button
     border-radius: 2px
   .logo
-    color: $steel-gray
+    color: $steel-gray-text
     width: $logo-dimension
     height: $logo-dimension
-    background-color: white
-    border: 1px solid $steel-gray
+    background-color: $white
+    border: 1px solid $steel-gray-text
     padding: 1px
     cursor: pointer
     label
@@ -282,10 +282,10 @@ $logo-dimension: 62px
   vertical-align: middle
   margin-right: 5px
   cursor: pointer
-  background: white
+  background: $white
 
 .checkbox
-  color: $steel-gray
+  color: $steel-gray-text
   input[type=checkbox]
     visibility: hidden
     width: 0
@@ -299,7 +299,7 @@ $logo-dimension: 62px
     cursor: pointer
     .checkbox__box
       @include checkbox-and-radio
-      border: 1px solid $steel-gray
+      border: 1px solid $steel-gray-text
 
 .checkbox--indeterminate
   label
@@ -308,7 +308,7 @@ $logo-dimension: 62px
       background-position: 3px -1px
       background-size: 70%
       background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M24 9 h-9 h-6 h-9 v6 h9 h6 h9 z' fill='%236e7f89'/%3E%3C/svg%3E");
-      border-color: $steel-gray
+      border-color: $steel-gray-text
 
 .radios
   display: inline-block
@@ -316,11 +316,11 @@ $logo-dimension: 62px
     width: 0
     visibility: hidden
     &:checked + label, &:checked + .radio > label
-      background-color: white
+      background-color: $white
       &::after
         position: absolute
         content: ' '
-        background-color: $steel-gray
+        background-color: $steel-gray-text
         border: 0
         border-radius: 10px
         width: 12px
@@ -329,11 +329,11 @@ $logo-dimension: 62px
         left: 2px
   label
     @include checkbox-and-radio
-    border: 1px solid $steel-gray
+    border: 1px solid $steel-gray-text
     border-radius: 10px
     background-color: $grey
     transition: background-color 0.3s linear
-    background-color: white
+    background-color: $white
     margin: 0 6px 0 6px
     width: 18px
     height: 18px
@@ -342,7 +342,7 @@ $logo-dimension: 62px
 .radio
   +desktop
     margin: 16px
-  border: 1px solid $steel-gray
+  border: 1px solid $steel-gray-text
   border-radius: 20px
   width: 20px
   height: 20px
@@ -351,7 +351,7 @@ $logo-dimension: 62px
   opacity: 0.4
 
 .quill
-  border-color: $steel-gray
+  border-color: $steel-gray-text
   +desktop
     max-width: 470px
   +mobile
@@ -398,7 +398,7 @@ $logo-dimension: 62px
     box-shadow: 0 0 0 5px $light-red !important
 
 .pseudo-link
-  color: $steel-gray
+  color: $steel-gray-text
   font-weight: $font-semi-bold
   text-decoration: underline
 

--- a/client/styles/_homepage.sass
+++ b/client/styles/_homepage.sass
@@ -1,11 +1,11 @@
 $homepage-max-width: 1084px
 
 .companies-section
-  color: $steel-gray
+  color: $steel-gray-text
   font-family: $family-secondary
   font-size: 14px
   font-weight: $font-medium
-  background-color: white
+  background-color: $white
   line-height: 18px
   .columns
     height: 100px
@@ -35,7 +35,7 @@ $homepage-max-width: 1084px
 .homepage__top-content,
 .homepage__middle-content,
 .homepage__bottom-content
-  background: white
+  background: $white
 
 .homepage__top-content__container,
 .homepage__middle-content__container,
@@ -86,7 +86,7 @@ $homepage-max-width: 1084px
   +desktop
     margin-left: -48px
   h1
-    color: $steel-gray
+    color: $steel-gray-text
     font-weight: bold
     font-size: 44px
     line-height: 58px
@@ -299,7 +299,7 @@ $rocket-width: 200px
       font-size: 21px
       line-height: 28px
     font-weight: bold
-    color: $steel-gray
+    color: $steel-gray-text
     margin-bottom: 24px !important
     font-family: $family-primary
 
@@ -339,7 +339,7 @@ $rocket-width: 200px
   font-size: 16px
   line-height: 26px
   font-weight: bold
-  color: $steel-gray
+  color: $steel-gray-text
   margin-bottom: 18px
 
 .homepage__testimonial__logo
@@ -376,11 +376,11 @@ $rocket-width: 200px
   height: 178px
   +mobile
     margin: 0 0 8px 0px
-    border: 6px solid white
+    border: 6px solid $white
     height: 196px
   display: inline-block
   padding: 18px
-  color: $steel-gray
+  color: $steel-gray-text
   text-align: left
   font-size: 14px
   line-height: 20px

--- a/client/styles/_how_it_works.sass
+++ b/client/styles/_how_it_works.sass
@@ -35,7 +35,7 @@
     margin-top: 40px
 
 .how-it-works__header
-  background-color: white
+  background-color: $white
   min-height: 528px
   +mobile
     padding-bottom: 20px
@@ -76,7 +76,7 @@
     padding-right: 20px
     padding-top: 64px
   h1
-    color: $steel-gray
+    color: $steel-gray-text
     font-weight: bold
     font-size: 44px
     line-height: 58px
@@ -212,7 +212,7 @@
 
 .how-it-works__benefits,
 .how-it-works__faq
-  background-color: white
+  background-color: $white
   padding-top: 74px
   +mobile
     padding-top: 44px
@@ -478,7 +478,7 @@
     border-left: 0
     border-right: 0
     &:hover
-      background-color: white !important
+      background-color: $white !important
       color: $red !important
   &:nth-of-type(even)
     flex-direction: row-reverse

--- a/client/styles/_issues.sass
+++ b/client/styles/_issues.sass
@@ -82,7 +82,7 @@
     +mobile
       margin-bottom: 18px
   .description
-    color: $steel-gray
+    color: $steel-gray-text
   .info
     width: 100%
     margin-left: 18px
@@ -332,7 +332,7 @@ $issue-section-gap: 20px
   line-height: 1.71
   h1
     font-size: 14px
-    color: $steel-gray
+    color: $steel-gray-text
     font-weight: $font-medium
   p
     margin-bottom: 24px
@@ -417,7 +417,7 @@ $issue-section-gap: 20px
   p
     line-height: 15px
   padding: 18px
-  color: $steel-gray
+  color: $steel-gray-text
   +mobile
     display: flex
   .icon
@@ -551,7 +551,7 @@ $issue-sticky-hide-mobile-offset: 28px
     top: calc(#{$navbar-mobile-height - $issue-sticky-hide-mobile-offset} - #{$issue-sticky-mobile-height})
     width: 100%
     height: $issue-sticky-mobile-height
-  background-color: white
+  background-color: $white
   border-bottom: 1px solid $grey
   box-shadow: 5px 2px 4px 4px rgba(0, 0, 0, 0.2)
   transition: top 0.4s
@@ -912,7 +912,7 @@ $issue-sticky-hide-mobile-offset: 28px
     display: block
     margin: 2px 0px 18px 12px
     font-size: 14px
-    color: $steel-gray
+    color: $steel-gray-text
     font-weight: $font-medium
     line-height: 14px
     text-align: right
@@ -1066,7 +1066,7 @@ $issue-sticky-hide-mobile-offset: 28px
     padding-right: 20px
     padding-top: 64px
   h1
-    color: $steel-gray
+    color: $steel-gray-text
     font-weight: bold
     font-size: 48px
     line-height: 60px
@@ -1099,7 +1099,7 @@ $issue-sticky-hide-mobile-offset: 28px
       width: 100%
 
 .issues__sorting
-  color: $steel-gray
+  color: $steel-gray-text
   display: flex
   flex-direction: row
   align-items: center
@@ -1270,7 +1270,7 @@ $issue-sticky-hide-mobile-offset: 28px
   padding: 18px
   margin: 0 0 16px 0
   min-height: 100px
-  background-color: white
+  background-color: $white
   +mobile
     margin-bottom: 12px
   overflow: hidden
@@ -1326,7 +1326,7 @@ $issue-sticky-hide-mobile-offset: 28px
       margin-top: 18px
 
 .manage-issues__queries-loading
-  background-color: white
+  background-color: $white
   padding: 18px
   height: 72px
   width: 100%

--- a/client/styles/_job.sass
+++ b/client/styles/_job.sass
@@ -9,7 +9,7 @@
     left: 0
     height: 100%
     width: 100%
-    background-color: white
+    background-color: $white
     border: 1px solid black
 
 .jobs-board__jobs-list .jobs-board__jobs-list__content,
@@ -131,7 +131,7 @@
     bottom: 12px
     font-size: 13px
     line-height: 13px
-    color: $steel-gray
+    color: $steel-gray-text
     +mobile
       font-size: 11px
       line-height: 11px
@@ -183,7 +183,7 @@
   display: flex
   flex-direction: column
   justify-content: center
-  color: $steel-gray
+  color: $steel-gray-text
 
 .job-edit__remuneration__salary__slider
   .rc-slider
@@ -210,11 +210,11 @@ $description-height: 400px
   margin-bottom: 10px
 
 .job-edit__location__condensed-address
-  background-color: white
+  background-color: $white
   padding: 16px
   font-size: 14px
   line-height: 18px
-  color: $steel-gray
+  color: $steel-gray-text
   span
     display: block
 
@@ -261,7 +261,7 @@ $description-height: 400px
 
 .job
   section
-    background-color: white
+    background-color: $white
     padding: 3.5%
     margin-bottom: 12px
     &:last-of-type
@@ -505,7 +505,7 @@ $description-height: 400px
 
 .job__apply-on-behalf-note
   line-height: 18px
-  color: $steel-gray
+  color: $steel-gray-text
   div.clickable
     margin-left: 9px
     margin-bottom: 5px
@@ -515,7 +515,7 @@ $description-height: 400px
 .job__apply-on-behalf-confirmation
   line-height: 18px
   font-weight: 500
-  color: $steel-gray
+  color: $steel-gray-text
   display: block
   margin-top: 5px
 
@@ -573,7 +573,7 @@ $description-height: 400px
 .job__candidate-action__score
   display: flex
   margin-bottom: 18px
-  color: $steel-gray
+  color: $steel-gray-text
   +desktop
     flex-direction: column-reverse
   +mobile
@@ -725,7 +725,7 @@ $description-height: 400px
     font-size: 14px
     font-weight: $font-medium
     line-height: 18px
-    color: $steel-gray
+    color: $steel-gray-text
     @include job-issue-separator
   .issue
     @include job-issue-separator

--- a/client/styles/_job.sass
+++ b/client/styles/_job.sass
@@ -261,7 +261,7 @@ $description-height: 400px
 
 .job
   section
-    background-color: $white
+    background-color: $section-white
     padding: 3.5%
     margin-bottom: 12px
     &:last-of-type

--- a/client/styles/_layout.sass
+++ b/client/styles/_layout.sass
@@ -13,7 +13,7 @@ h1
 
 h2
   font-weight: $font-semi-bold
-  color: $steel-gray
+  color: $steel-gray-text
   font-size: 18px
   line-height: 22px
   +mobile
@@ -25,7 +25,7 @@ h2
 
 h3
   font-weight: $font-medium
-  color: $steel-gray
+  color: $steel-gray-text
   font-size: 14px
   line-height: 22px
   margin-bottom: 12px
@@ -74,7 +74,7 @@ h3
     margin-right: 20px
     min-width: 505px
   & > .split-content-section
-    background-color: white
+    background-color: $white
     padding: 18px
     .title
       font-size: 18px
@@ -94,7 +94,7 @@ h3
 .split-content__side
   & > .split-content-section
     margin: 0px
-    background-color: white
+    background-color: $white
     padding: 18px
     p
       line-height: 18px

--- a/client/styles/_layout.sass
+++ b/client/styles/_layout.sass
@@ -74,7 +74,7 @@ h3
     margin-right: 20px
     min-width: 505px
   & > .split-content-section
-    background-color: $white
+    background-color: $section-white
     padding: 18px
     .title
       font-size: 18px
@@ -94,7 +94,7 @@ h3
 .split-content__side
   & > .split-content-section
     margin: 0px
-    background-color: $white
+    background-color: $section-white
     padding: 18px
     p
       line-height: 18px

--- a/client/styles/_loaders.sass
+++ b/client/styles/_loaders.sass
@@ -4,7 +4,7 @@
   margin: 0
   width: 100%
   z-index: $loader-z-index
-  background: white
+  background: $white
   display: flex
   flex-direction: column
   justify-content: center

--- a/client/styles/_menu.sass
+++ b/client/styles/_menu.sass
@@ -1,5 +1,5 @@
 .menu-container
-  background-color: white
+  background-color: $white
   &.is-open
     height: calc(100% - #{$navbar-mobile-height});
     +mobile
@@ -14,7 +14,7 @@
     transition: height 0.5s
     overflow-y: hidden
   +desktop
-    border-right: 1px solid #dedede
+    border-right: 1px solid $grey
     padding: 20px 0px 20px 0
     position: fixed
     top: $navbar-height
@@ -40,7 +40,7 @@
     flex-direction: column
     align-items: flex-start
     justify-content: flex-start
-    background-color: white
+    background-color: $white
     section
       width: 100%
       flex: 0
@@ -61,7 +61,7 @@
     +mobile
       padding: 10px 18px
       height: 49px
-      color: white
+      color: $white
       background-color: $greyish
       width: 100%
   ul
@@ -79,7 +79,7 @@
     a
       color: $greyish
       &.disabled
-        color: $light-gray
+        color: $disabled-gray-text
         cursor: default
         .icon
           fill: $light-gray !important

--- a/client/styles/_metrics.sass
+++ b/client/styles/_metrics.sass
@@ -1,6 +1,6 @@
 .main-wrapper--metrics
   padding-top: 50px
-  background-color: white
+  background-color: $white
 
   table
     font-family: $family-secondary

--- a/client/styles/_navbar.sass
+++ b/client/styles/_navbar.sass
@@ -9,8 +9,8 @@ $navbar-overlay-content-width: 260px
   width: 100%
   display: flex
   align-items: stretch
-  border-bottom: #dedede 1px solid
-  background-color: white
+  border-bottom: $grey 1px solid
+  background-color: $white
   +desktop
     height: $navbar-height
   +mobile
@@ -69,7 +69,7 @@ $navbar-overlay-content-width: 260px
       height: 0px
       margin: 0px 18px
       padding: 0
-      border-top: 1px solid white
+      border-top: 1px solid $white
     &.is-open
       height: 100%
       border-top: 1px solid $white-two
@@ -85,21 +85,21 @@ $navbar-overlay-content-width: 260px
     padding: 12px 18px
     font-size: 12px
     line-height: 24px
-    color: $steel-gray
+    color: $steel-gray-text
     font-weight: $font-semi-bold
 
   .navbar-menu-item:last-of-type
     background-color: $red
-    color: white
+    color: $white
     font-weight: bold
     text-transform: uppercase
 
   .navbar-menu--candidates
-    background-color: white
+    background-color: $white
     height: 0px
     transition: height 0.3s
     overflow-y: hidden
-    color: $steel-gray
+    color: $steel-gray-text
     div:first-child
       padding: 20px 0px 0px 26px
     &.is-open
@@ -158,7 +158,7 @@ $navbar-overlay-content-width: 260px
       padding: 0
       border: none
       outline: none
-      fill: $steel-gray
+      fill: $steel-gray-text
       width: 44px
       height: 100%
       background-color: $pale-gray
@@ -184,7 +184,7 @@ $navbar-overlay-content-width: 260px
     line-height: 32px
     font-weight: $font-semi-bold
     letter-spacing: 0.5px
-    color: $steel-gray
+    color: $steel-gray-text
     +mobile
       font-size: 12px
 
@@ -200,7 +200,7 @@ $navbar-overlay-content-width: 260px
     cursor: pointer
     transition: color 0.3s
     .icon
-      fill: $steel-gray
+      fill: $steel-gray-text
       width: 24px
       height: 24px
       margin: 3px 0px 0px 0px
@@ -215,12 +215,12 @@ $navbar-overlay-content-width: 260px
   .navbar-item--menu
     font-size: 10px
     font-weight: bold
-    background-color: $steel-gray
+    background-color: $steel-gray-text
     border-radius: 4px
     height: 25px
     padding: 0 16px
     margin: 12px 0 !important
-    color: white
+    color: $white
     line-height: 14px
     .navbar__unfinished-task-count
       position: absolute
@@ -230,7 +230,7 @@ $navbar-overlay-content-width: 260px
       line-height: 25px
     &:hover
       background-color: $greyish !important
-      color: white !important
+      color: $white !important
 
   .navbar-item--menu--open
     background-color: $greyish !important
@@ -245,10 +245,10 @@ $navbar-overlay-content-width: 260px
     +mobile
       margin-top: 2px
   a.navbar-item:hover
-    background-color: white
+    background-color: $white
     color: $red
   a.navbar-item--register:hover,
-    background-color: white
+    background-color: $white
 
   .navbar-item--login:hover
     +desktop
@@ -260,7 +260,7 @@ $navbar-overlay-content-width: 260px
     padding-right: 2px
 
   .logo-title-container
-    color: $steel-gray
+    color: $steel-gray-text
     line-height: 1em
 
   .logo-title
@@ -353,7 +353,7 @@ $navbar-overlay-content-width: 260px
       border-bottom: 4px solid $greyish
       background: none
       outline: none
-      color: $steel-gray
+      color: $steel-gray-text
       display: inline-block
       width: 100%
     .search::placeholder
@@ -366,7 +366,7 @@ $navbar-overlay-content-width: 260px
     border: none
     background: none
     .icon
-      fill: $steel-gray
+      fill: $steel-gray-text
       width: 32px
       height: 32px
 
@@ -408,11 +408,11 @@ $navbar-overlay-content-width: 260px
       z-index: 2
     .navbar-overlay__content
       border: 2px solid $red
-      background-color: white
+      background-color: $white
       width: $navbar-overlay-content-width
       top: -12px
       font-size: 14px
-      color: $steel-gray
+      color: $steel-gray-text
       box-shadow: 0 2px 4px 0 $greyish
 
   @mixin overlay-offset($amount)
@@ -439,7 +439,7 @@ $navbar-overlay-content-width: 260px
         line-height: 1
         margin-bottom: 6px
       p
-        color: $steel-gray
+        color: $steel-gray-text
         line-height: 20px
         font-size: 13px
         margin: 0
@@ -473,7 +473,7 @@ $navbar-overlay-content-width: 260px
   .navbar-menu--candidates__vertical-link
     display: block
     padding-left: 26px
-    color: $steel-gray
+    color: $steel-gray-text
     display: flex
     align-items: center
     line-height: 1em
@@ -527,14 +527,14 @@ $navbar-overlay-content-width: 260px
 .navbar__unfinished-task-count
   background-color: $red
   padding: 4px 4px
-  color: white
+  color: $white
   line-height: 0.9
   border-radius: 9px
   font-size: 10px
   font-weight: $font-medium
   height: 18px
   width: 18px
-  border: 1px solid white
+  border: 1px solid $white
   text-align: center
   font-family: $family-primary
 
@@ -557,17 +557,17 @@ $tasks-width-desktop: 320px
     z-index: 2
   .navbar-overlay__content
     border: 2px solid $red
-    background-color: white
+    background-color: $white
     width: 100%
     top: 12px
     font-size: 14px
-    color: $steel-gray
+    color: $steel-gray-text
     box-shadow: 0 2px 4px 0 $greyish
 
 .navbar__tasks-header
   padding: 12px
   background: $red
-  color: white
+  color: $white
   font-size: 12px
   line-height: 15px
   font-weight: $font-semi-bold
@@ -582,7 +582,7 @@ $tasks-width-desktop: 320px
     line-height: 0
     font-size: 12px
     font-weight: $font-medium
-    color: $steel-gray
+    color: $steel-gray-text
     justify-content: space-between
     align-items: center
     width: 100%
@@ -594,7 +594,7 @@ $tasks-width-desktop: 320px
     font-size: 12px
     line-height: 15px
     font-weight: $font-regular
-    color: $steel-gray
+    color: $steel-gray-text
     margin-top: 6px
   .icon
     fill: $red
@@ -603,7 +603,7 @@ $tasks-width-desktop: 320px
 
 .navbar__task--read,
 .navbar__task--complete
-  background-color: white
+  background-color: $white
 
 .navbar__task--complete
   p

--- a/client/styles/_newsletter_subscription.sass
+++ b/client/styles/_newsletter_subscription.sass
@@ -31,7 +31,7 @@
     width: 100%
     height: 40px
     padding: 0 12px
-    color: $steel-gray
+    color: $steel-gray-text
     font-weight: 600
     @include form-fieldx
   .newsletter-subscription__input::placeholder
@@ -70,7 +70,7 @@
     +desktop
       height: 64px
   .newsletter-subscription__primary-text
-    color: white
+    color: $white
     font-weight: 600
     font-size: 20px
     animation-duration: 1s

--- a/client/styles/_number_circle.sass
+++ b/client/styles/_number_circle.sass
@@ -3,7 +3,7 @@
   width: 32px
   height: 32px
   background-color: $red
-  color: white
+  color: $white
   border-radius: 32px
   text-align: center
   font-size: 18px
@@ -11,6 +11,6 @@
   padding-top: 1px
 
 .number-circle--inverted
-  background-color: white
+  background-color: $white
   color: $red
   border: 1px solid $red

--- a/client/styles/_overlay.sass
+++ b/client/styles/_overlay.sass
@@ -36,7 +36,7 @@
 
 .overlay__content
   box-shadow: 0 1px 6px 0 rgba(0, 0, 0, 0.2)
-  background-color: white
+  background-color: $white
   position: relative
   +desktop
     width: 500px
@@ -74,7 +74,7 @@
 .overlay__close
   .icon
     position: absolute
-    fill: $steel-gray
+    fill: $steel-gray-text
     right: 16px
     cursor: pointer
     width: 32px
@@ -98,7 +98,7 @@
     margin: auto 10px
   padding: 18px
   margin: auto 0;
-  background: white
+  background: $white
   box-shadow: 2px 2px 4px 0 rgba(0, 0, 0, 0.3)
   p
     line-height: 16px
@@ -118,4 +118,4 @@
   .icon
     width: 28px
     height: 28px
-    fill: $steel-gray
+    fill: $steel-gray-text

--- a/client/styles/_packages.sass
+++ b/client/styles/_packages.sass
@@ -28,7 +28,7 @@
 
 .package-selector__column
   position: relative
-  color: $steel-gray
+  color: $steel-gray-text
   text-align: center
   padding: 0
   +desktop
@@ -40,13 +40,13 @@
 
 .package-selector__column-inner
   padding: 38px 18px 18px 18px
-  background-color: white
+  background-color: $white
   +mobile
     margin-bottom: 40px
 
 .package-selector__title
   margin-top: 26px
-  color: $steel-gray
+  color: $steel-gray-text
   font-size: 18px
   font-weight: $font-semi-bold
   line-height: 18px
@@ -59,7 +59,7 @@
 .package-selector__price
   display: flex
   flex-direction: column
-  color: $steel-gray
+  color: $steel-gray-text
   position: relative
   max-width: 200px
   margin: 0 auto
@@ -93,7 +93,7 @@
     border-radius: 4px
 
 .package-selector__button--restricted
-  background: white
+  background: $white
   color: $greyish
   border: solid 1px $greyish
   pointer-events: none
@@ -107,7 +107,7 @@
   div
     margin-top: 7px
   strong
-    color: $steel-gray
+    color: $steel-gray-text
     font-size: 12px
     font-weight: $font-semi-bold
     line-height: 14px
@@ -181,7 +181,7 @@
     height: 37px
     width: 37px
   svg:last-child
-    fill: white
+    fill: $white
     position: absolute
     top: 10px
     left: 10px
@@ -190,7 +190,7 @@
   &>div
     position: absolute
     top: 165px
-    color: white
+    color: $white
   &>div:first-child
     left: 0px
   &>div:last-child
@@ -238,13 +238,13 @@
     background-color: $green
     height: 100%
     p
-      color: white
+      color: $white
       margin-top: 30px
       text-align: left
       line-height: 24px
   .icon
     position: absolute
-    fill: white
+    fill: $white
     width: 24px
     height: 24px
   .info-icon

--- a/client/styles/_pagination.sass
+++ b/client/styles/_pagination.sass
@@ -18,6 +18,6 @@
     color: #c5c6c5
     transition: background-color $transition-time, color $transition-time
   &.is-current
-    border: solid 1px $steel-gray
+    border: solid 1px $steel-gray-text
     background-color: $steel-gray
     color: $white

--- a/client/styles/_payment.sass
+++ b/client/styles/_payment.sass
@@ -13,12 +13,12 @@
 
 .payment-setup__content
   position: relative
-  color: $steel-gray
+  color: $steel-gray-text
   p
     line-height: 18px
     margin-bottom: 18px
   h1
-    color: $steel-gray
+    color: $steel-gray-text
     font-size: 14px
     font-weight: $font-medium
     line-height: 18px
@@ -41,7 +41,7 @@
   padding: 24px 48px 48px 48px
   margin: auto 0
   margin-top: -100px
-  background: white
+  background: $white
   box-shadow: 2px 2px 4px 0 rgba(0, 0, 0, 0.3)
   position: relative
   p
@@ -94,8 +94,8 @@
   background-color: $red
   color: $white
 .StripeForm
-  background-color: white
-  border: 1px solid $steel-gray
+  background-color: $white
+  border: 1px solid $steel-gray-text
   padding: 14px
   margin-top: 16px
   .error
@@ -106,7 +106,7 @@
       display: none
 
 .payment-setup__pay-success
-  background: white
+  background: $white
   padding: 24px
   svg
     fill: $green
@@ -138,7 +138,7 @@
   padding: 18px
   height: 80px
   width: 100%
-  background-color: white
+  background-color: $white
   display: flex
   margin-bottom: 18px
 .card-data__brand
@@ -186,7 +186,7 @@
   justify-content: space-around
   @include animation('payment-card-final-reveal 0.5s 1')
   h1
-    color: white
+    color: $white
 
 .payment-publish-celebration__content
   padding: 18px
@@ -202,12 +202,12 @@
     top: $navbar-mobile-height + 12px
   right: 12px
   svg
-    fill: white
+    fill: $white
     width: 32px
     height: 32px
 
 .payment-setup__pay-confirm-container
-  background: white
+  background: $white
   padding: 24px
   position: relative
   font-size: 14px
@@ -234,7 +234,7 @@
   .is-flex
     justify-content: space-between
   strong
-    color: $steel-gray
+    color: $steel-gray-text
     font-weight: $font-medium
     line-height: 24px
   i
@@ -284,7 +284,7 @@
     display: flex
     flex-direction: column
     align-items: center
-    background-color: white
+    background-color: $white
     border: 1px solid transparent
     +desktop
       margin-left: 0 !important
@@ -309,7 +309,7 @@
       letter-spacing: 0.5px
       margin-top: 12px
     &.checked
-      border: 1px solid $steel-gray
+      border: 1px solid $steel-gray-text
     &.disabled
     &.existing, &.disabled
       span
@@ -362,7 +362,7 @@
     cursor: pointer
     justify-content: flex-start
   svg
-    fill: $steel-gray
+    fill: $steel-gray-text
   form
     display: flex
     .button
@@ -432,7 +432,7 @@
     position: absolute
     bottom: -14px
     margin-left: -32px
-    background-color: white
+    background-color: $white
     padding: 0px 32px
   li
     display: flex

--- a/client/styles/_pods.sass
+++ b/client/styles/_pods.sass
@@ -1,9 +1,9 @@
 .pod
   position: relative
-  background-color: white
+  background-color: $white
   box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.3)
   padding: 18px
-  color: $steel-gray
+  color: $steel-gray-text
   width: 100%
   min-width: 250px
   margin-bottom: 18px
@@ -26,7 +26,7 @@
     margin-top: 8px
     font-size: 18px
     font-weight: 600
-    color: $steel-gray
+    color: $steel-gray-text
   h2
     &:not(:first-child)
       margin-top: 6px

--- a/client/styles/_policy.sass
+++ b/client/styles/_policy.sass
@@ -1,7 +1,7 @@
 .privacy
   @include margins
   position: relative
-  background-color: white
+  background-color: $white
   +desktop
     margin-top: 19px
     margin-bottom: 19px

--- a/client/styles/_pricing.sass
+++ b/client/styles/_pricing.sass
@@ -1,6 +1,6 @@
 .main-wrapper--pricing
   padding-top: 50px
-  background-color: white
+  background-color: $white
 
 .pricing
   .package-selector__column-inner
@@ -39,7 +39,7 @@
 
 .pricing__faqs__question__title
   font-family: $family-primary
-  color: $steel-gray
+  color: $steel-gray-text
   font-size: 18px
   font-weight: bold
   line-height: 22px
@@ -51,7 +51,7 @@
       margin-top: -6px
       margin-right: -10px
       margin-left: 10px
-      fill: $steel-gray
+      fill: $steel-gray-text
       min-width: 32px
       min-height: 32px
       transition: transform 0.2s

--- a/client/styles/_profile.sass
+++ b/client/styles/_profile.sass
@@ -26,14 +26,14 @@ $avatar-size-mobile: 60px
 
   .profile-section
     position: relative
-    background: white
+    background: $white
     padding: 25px
 
   .header
     text-align: center
     font-size: 12px
     .name
-      color: $steel-gray
+      color: $steel-gray-text
       font-size: 18px
       font-weight: $font-semi-bold
       line-height: 22px
@@ -94,7 +94,7 @@ $avatar-size-mobile: 60px
 
   .timeline-item
     width: 346px
-    background: white
+    background: $white
     margin: 30px
     float: left
     text-align: center
@@ -112,7 +112,7 @@ $avatar-size-mobile: 60px
 
   .private
     .private__disclaimer
-      color: $steel-gray
+      color: $steel-gray-text
       font-variant: italic
 
     .private__field
@@ -185,7 +185,7 @@ $avatar-size-mobile: 60px
     overflow-y: hidden
     overflow-x: auto
     +mobile
-      background: white
+      background: $white
     .avatar
       width: $avatar-size
       height: $avatar-size
@@ -205,7 +205,7 @@ $avatar-size-mobile: 60px
 .profile-section__applications__job
   border-bottom: 1px solid $pale-gray
   padding: 10px 0px 12px 0px
-  color: $steel-gray
+  color: $steel-gray-text
   &:last-of-type
     border-bottom: 0
   +mobile

--- a/client/styles/_profile.sass
+++ b/client/styles/_profile.sass
@@ -26,7 +26,7 @@ $avatar-size-mobile: 60px
 
   .profile-section
     position: relative
-    background: $white
+    background: $section-white
     padding: 25px
 
   .header

--- a/client/styles/_progress_bar.sass
+++ b/client/styles/_progress_bar.sass
@@ -14,7 +14,7 @@
 
 .progress-bar__background
   height: 18px
-  color: white
+  color: $white
   background-image: repeating-linear-gradient(-45deg, $green-tint, $green-tint 5px, #fff 5px, #fff 10px)
   background-size: 150% 100%
   &.animated
@@ -31,7 +31,7 @@
 .progress-bar__marker
   height: 18px
   width: 0%
-  border-left: 1px solid white
+  border-left: 1px solid $white
   position: relative
   &:first-of-type
     &::after

--- a/client/styles/_public_pages.sass
+++ b/client/styles/_public_pages.sass
@@ -1,5 +1,5 @@
 .public__title
-  color: $steel-gray
+  color: $steel-gray-text
   font-size: 44px
   font-weight: bold
   line-height: 58px

--- a/client/styles/_register.sass
+++ b/client/styles/_register.sass
@@ -149,7 +149,7 @@ $line-height: 1.5
   visibility: hidden
 
 .conversation-element
-  background: $white
+  background: $section-white
   color: $wh-black
   padding: 12px 20px
   margin: 10px

--- a/client/styles/_register.sass
+++ b/client/styles/_register.sass
@@ -149,7 +149,7 @@ $line-height: 1.5
   visibility: hidden
 
 .conversation-element
-  background: white
+  background: $white
   color: $wh-black
   padding: 12px 20px
   margin: 10px
@@ -162,27 +162,34 @@ $line-height: 1.5
   code
     font-size: $font-size
   .location
-    color: $steel-gray
+    color: $steel-gray-text
     font-weight: $font-semi-bold
   &.codi
     border-radius: $radius $radius $radius 0
   &.user
     margin-left: auto
     margin-right: 18px
-    border: 2px solid $steel-gray
+    border: 2px solid $steel-gray-text
     border-radius: $radius $radius 0 $radius
+
     input
+      background-color: $white
       border: none
-      color: $steel-gray
+      color: $steel-gray-text
       font-weight: $font-semi-bold
       width: 100%
       &:focus
         outline: none
+
+    input:-webkit-autofill
+      -webkit-text-fill-color: $steel-gray-text
+      box-shadow: 0 0 0 30px $white inset !important
+
     li
-      color: $steel-gray
+      color: $steel-gray-text
       line-height: 2.3
     ul
-      border-top: $steel-gray 2px solid
+      border-top: $steel-gray-text 2px solid
       padding-top: 8px
       margin-top: 5px
 
@@ -238,7 +245,7 @@ $line-height: 1.5
     height: 40px
 
 .github-button__caption
-  color: white
+  color: $white
   font-weight: $font-semi-bold
   font-size: 12px
   text-align: center
@@ -252,8 +259,8 @@ $line-height: 1.5
   display: flex
   height: 42px
   border: none
-  background: $steel-gray
-  color: white
+  background: $steel-gray-text
+  color: $white
   font-weight: $font-medium
   font-size: $font-size
   line-height: $line-height
@@ -266,12 +273,12 @@ $line-height: 1.5
   transition: background 0.3s
   align-items: center
   &:hover
-    color: white
+    color: $white
     background: $red
   input:disabled + &,  &:disabled
     color: $dark-gray
   .icon
-    fill: white
+    fill: $white
     vertical-align: middle
     margin-right: 12px
 

--- a/client/styles/_search.sass
+++ b/client/styles/_search.sass
@@ -12,7 +12,7 @@ $search-gap: 2.5px
   right: 0
   top: 0
   bottom: 0
-  background-color: white
+  background-color: $white
   opacity: 0.8
   z-index: 1000
   display: flex
@@ -36,7 +36,7 @@ $search-gap: 2.5px
   position: relative
 
 .search__box
-  background-color: white
+  background-color: $white
   margin: $search-gap
   &.search__box-no-margin
     margin: $search-gap 0
@@ -159,7 +159,7 @@ $search-gap: 2.5px
 .search__reset
   vertical-align: middle
   float: right
-  fill: white
+  fill: $white
   transition: fill 0.3s linear
   cursor: pointer
 
@@ -246,7 +246,7 @@ $search-gap: 2.5px
     width: 400px
     max-width: 100%
     z-index: 10
-    background: white
+    background: $white
 
 .search__country
   margin-left: 20px

--- a/client/styles/_selector.sass
+++ b/client/styles/_selector.sass
@@ -19,7 +19,7 @@ $transition-time: 0.2s
   text-transform: uppercase
   border: 1px solid $greyish
   cursor: pointer
-  background-color: white
+  background-color: $white
   transition: background-color $transition-time, color $transition-time
   &:hover
     background-color: $pale-gray
@@ -27,6 +27,6 @@ $transition-time: 0.2s
     border-left: unset
 .selector__option--selected
   background-color: $steel-gray
-  color: white
+  color: $white
   &:hover
     background-color: $steel-gray

--- a/client/styles/_stats.sass
+++ b/client/styles/_stats.sass
@@ -23,7 +23,7 @@
   width: 50px
   border-right: 1px solid $pale-gray
   .icon
-    fill: $steel-gray !important
+    fill: $steel-gray-text !important
     width: 18px
     height: 18px
 
@@ -49,7 +49,7 @@
   margin-left: 16px
   line-height: 24px
   align-self: end
-  color: $steel-gray
+  color: $steel-gray-text
   letter-spacing: 1px
   text-transform: uppercase
 
@@ -69,7 +69,7 @@
 .stats__increase
   display: inline-block
   padding-left: 6px
-  color: $steel-gray
+  color: $steel-gray-text
   font-weight: $font-medium
   font-size: 12px
 

--- a/client/styles/_sticky.sass
+++ b/client/styles/_sticky.sass
@@ -1,6 +1,6 @@
 .sticky
   position: fixed
-  background-color: white
+  background-color: $white
   border-bottom: 1px solid $grey
   transition: top 0.4s
   padding: 12px

--- a/client/styles/_tabs.sass
+++ b/client/styles/_tabs.sass
@@ -27,7 +27,7 @@
     +desktop
       margin-left: 4px
   &:hover
-    background-color: white
+    background-color: $white
   +mobile
     width: 100%
 
@@ -36,7 +36,7 @@
     order: 1
     z-index: 100
   color: $red
-  background-color: white
+  background-color: $white
   border-color: $red
 
 .tab__roll-down--expanded

--- a/client/styles/_tags.sass
+++ b/client/styles/_tags.sass
@@ -26,8 +26,8 @@ $tag-spacing: 3px
 .tags li:not(.tag)
   margin-right: $tag-spacing
   margin-bottom: $tag-spacing
-  background-color: $lighter-red
-  color: $red
+  background-color: $tag-background
+  color: $tag-text
 .tags li, .tag
   margin-right: $tag-spacing
   margin-bottom: $tag-spacing
@@ -125,8 +125,8 @@ $tag-spacing: 3px
   text-overflow: ellipsis
   white-space: nowrap
   overflow: hidden
-  background-color: $lighter-red
-  color: $red
+  background-color: $tag-background
+  color: $tag-text
   .icon:not(.icon--close) + span
     margin-left: 18px
   .icon

--- a/client/styles/_tags.sass
+++ b/client/styles/_tags.sass
@@ -65,10 +65,10 @@ $tag-spacing: 3px
     input
       @include hover-focus-state
 .tags-selection
-  color: $steel-gray
-  border: 1px solid $steel-gray
+  color: $steel-gray-text
+  border: 1px solid $steel-gray-text
   border-top: 0
-  background-color: white
+  background-color: $white
   position: relative
   padding: 1px
   @include splitter-hr(15px)
@@ -173,9 +173,9 @@ $tag-spacing: 3px
 
 .tag--type-company, .tag.tag--type-company
   background-color: $disabled-gray
-  color: $steel-gray
+  color: $steel-gray-text
   .icon
-    fill: $steel-gray
+    fill: $steel-gray-text
 
 .tag--type-industry, .tag.tag--type-industry
   background-color: $tag-bg-orange
@@ -206,7 +206,7 @@ $tag-spacing: 3px
       min-width: 200px
 
 .edit-tags__list
-  background-color: white
+  background-color: $white
   li + li
     border-top: 1px solid rgba(0,0,0,0.1)
 

--- a/client/styles/_tooltip.sass
+++ b/client/styles/_tooltip.sass
@@ -4,8 +4,8 @@ $tooltip-max-width: 300px
   position: relative
   display: inline-block
   .tooltip
-    background-color: white
-    color: $steel-gray !important
+    background-color: $white
+    color: $steel-gray-text !important
     font-size: 12px
     line-height: 18px
     text-align: left

--- a/client/styles/_videos.sass
+++ b/client/styles/_videos.sass
@@ -27,13 +27,13 @@ $video-lower-height: 115px
   align-items: center
   cursor: pointer
   .icon
-    fill: white
+    fill: $white
     width: 48px
     height: 48px
 .video_lower
   height: $video-lower-height
   width: $video-width
-  background-color: white
+  background-color: $white
 .video_lower--editable
   height: calc(#{$video-lower-height} + 28px)
 .video_description

--- a/client/styles/_wh.sass
+++ b/client/styles/_wh.sass
@@ -143,7 +143,7 @@ $loader-z-index: 800
     justify-content: center
 
 #app, #app-ssr
-  background-color: $pale-gray
+  background-color: $app-background
   &.app--hidden
     display: none
 
@@ -271,7 +271,6 @@ $loader-z-index: 800
 
 html, body
   background-color: $wh-background
-//  color: $more-gray
   +desktop
     width: 100%
     overflow: visible

--- a/client/styles/_wh.sass
+++ b/client/styles/_wh.sass
@@ -1,78 +1,6 @@
-@import "../vendor/bulma/sass/utilities/initial-variables"
 //@import url('https://fonts.googleapis.com/css?family=Montserrat:400,400i,500,600,800')
 // maybe we dont need 800 if we are not rendering logo in text
 // 2. Set your own initial variables
-
-$twitter-blue: #1da1f2
-$twitter-blue-hover: #4db5f5
-$twitter-grey: #bcbbbb
-$stackoverflow-grey: #bcbbbb
-$wh-white: white
-$github-black: #24292e
-$github-black-hover: #444d56
-$github-white: white
-$placeholder-grey: #adadad
-$button-hover: #ff9f95
-$circle-logo-backround: #f5f4f8
-$circle-logo-border: $green
-$dark-gray: #98BAC8
-$dark-red: #c4000f
-$dark-salmon: #bf5d52
-$disabled-gray: #e8e8e8
-$green: #80b5bc
-$green-tint: #dae8eb
-$green-tint-end: #b7dbdf
-$grey-blue: #97bac9
-$grey-darker: #434E55
-$grey: #dedede
-$greyish: #adadad
-$hero-grey: #f5f8fa
-$hover-red: #ffb1a8
-$light-blue-grey: #c4d4dd
-$light-blue: #d4f4f2
-$light-gray: #e6edf2
-$light-orange: #ffae71
-$light-peach: #f9e3d4
-$light-red: #ffdedb
-$lighter-gray: #e5e8ea
-$lighter-red2: #feecea
-$lighter-red: #ffe9e7
-$main-black: #4a4a4a
-$metal-blue: #7eb5bd
-$more-gray: #d8d8d8
-$pale-gray: #f4f5f8
-$pale-red: #ffd4cf
-$pale-blue: #e2e5e7
-$pinkish-grey: #bcbcbc
-$red: #ff7c6e
-$hover-orange: #ff9f90
-$sand: #f7f3f0
-$skeleton-background-color: #ddd
-$snow: #fffaf9
-$steel-gray: #6E7F89
-$wh-black: #171717
-$white-two: #dbdbdb
-$pale-blue: #f2f7f8
-$sea-blue: #136d79
-$tag-bg-orange: #fff1e7
-$tag-orange: #FF913E
-$tag-bg-blue: #e7f0f2
-$tag-col-blue: #5197B4
-$tag-bg-blue2: #ecf2f9
-$tag-col-blue2: #437fcc
-$tag-bg-green: #ebf5eb
-$tag-green: #5EA62E
-
-$hired-color: #276749
-$hired-background: #9AE6B4
-$rejected-color: #9B2C2C
-$rejected-background: #FEB2B2
-$pending-color: #975A16
-$pending-background: #FAF089
-
-$steel-gray-with-alpha: rgba(37, 65, 84, 0.6)
-
-$hover-colors: $light-red, $light-orange, $red, $metal-blue, $light-peach, $grey-blue, $light-blue-grey, $steel-gray
 
 $font-regular: 400
 $font-medium: 500
@@ -112,7 +40,7 @@ $navbar-mobile-logo-height: 26px
 $navbar-background-color: transparent
 $promo-banner-height: 48px
 
-$file-cta-hover-color: white
+$file-cta-hover-color: $white
 $file-cta-background-color: $red
 
 $navbar-z-index: 900
@@ -139,6 +67,19 @@ $loader-z-index: 800
 @import "../vendor/bulma/sass/components/message"
 @import "../vendor/bulma/sass/components/navbar"
 @import "../vendor/bulma/sass/components/pagination"
+@import "../vendor/bulma-switch/sass/index"
+
+@import "../vendor/rc-slider/rc-slider"
+@import "../vendor/quill/quill.snow-custom"
+
+.ql-container.ql-snow
+  background-color: $white
+
+.ql-toolbar.ql-snow
+  background-color: $white
+
+.ql-snow
+  background-color: $white
 
 @keyframes show-mobile-search
   from
@@ -195,7 +136,7 @@ $loader-z-index: 800
     left: 0
     right: 0
     bottom: 0
-    background-color: white
+    background-color: $white
     z-index: 50
     display: flex
     align-items: center
@@ -222,7 +163,7 @@ $loader-z-index: 800
 =popup
   box-shadow: 0 2px 10px 0 rgba(0, 0, 0, 0.2)
   position: fixed
-  background: white
+  background: $white
   z-index: 1000
   color: $wh-black
   line-height: 27px
@@ -329,6 +270,8 @@ $loader-z-index: 800
 @import "cta_pod"
 
 html, body
+  background-color: $wh-background
+//  color: $more-gray
   +desktop
     width: 100%
     overflow: visible
@@ -338,6 +281,3 @@ html
 
 .no-scroll
   overflow: hidden
-
-@import "../vendor/rc-slider/rc-slider"
-@import "../vendor/quill/quill.snow-custom"

--- a/client/styles/wh-dark.sass
+++ b/client/styles/wh-dark.sass
@@ -1,25 +1,27 @@
 // bulma initial colors
-$black:        #ffffff
-$black-bis:    #ffffdd
-$black-ter:    #ffffaa
+$black: #ffffff
+$black-bis: #ffffdd
+$black-ter: #ffffaa
 
-$grey: 	       #595959
-$grey-darker:  #d9d9d9
-$grey-dark:    #bfbfbf
-$grey-light:   #393939
+$grey: #595959
+$grey-darker: #d9d9d9
+$grey-dark: #bfbfbf
+$grey-light: #393939
 $grey-lighter: #191919
 
-$white-ter:    #383838
-$white-bis:    #303030
-$white:        #282828
+$white-ter: #383838
+$white-bis: #303030
+$white: #242730
 
-$green:        #80b5bc
-$red: 	       #ff7c6e
+$green: #80b5bc
+$red: #ff7c6e
+
+$input-background-color: #2f3340
 
 @import "../vendor/bulma/sass/utilities/initial-variables"
 
 // bulma-switch primary colors
-$primary:      $grey-dark
+$primary: $grey-dark
 $primary-invert: $grey-light
 
 $twitter-blue: #1da1f2
@@ -30,7 +32,7 @@ $github-black: #9ba6b0
 $github-black-hover: #657380
 $github-white: $white
 $placeholder-grey: #595959
-$button-hover: #b31100
+$button-hover: #ffe8e5
 $circle-logo-backround: #4f456d
 $circle-logo-border: $green
 $dark-gray: #3e6574
@@ -86,8 +88,12 @@ $pending-background: #ab9d07
 
 $wh-background: #282828
 $steel-gray-text: #9ca8b0
-$light-gray-text: #abc3d3
 $disabled-gray-text: $lighter-gray
+$section-white: #2f3340
+$app-background: $white
+$tag-background: #3c4c56
+$tag-text: #d9d9d9
+$footer-text: #abc3d3
 
 $steel-gray-with-alpha: rgba(131, 172, 200, 0.6)
 

--- a/client/styles/wh-dark.sass
+++ b/client/styles/wh-dark.sass
@@ -1,0 +1,96 @@
+// bulma initial colors
+$black:        #ffffff
+$black-bis:    #ffffdd
+$black-ter:    #ffffaa
+
+$grey: 	       #595959
+$grey-darker:  #d9d9d9
+$grey-dark:    #bfbfbf
+$grey-light:   #393939
+$grey-lighter: #191919
+
+$white-ter:    #383838
+$white-bis:    #303030
+$white:        #282828
+
+$green:        #80b5bc
+$red: 	       #ff7c6e
+
+@import "../vendor/bulma/sass/utilities/initial-variables"
+
+// bulma-switch primary colors
+$primary:      $grey-dark
+$primary-invert: $grey-light
+
+$twitter-blue: #1da1f2
+$twitter-blue-hover: #4db5f5
+$twitter-grey: #bcbbbb
+$stackoverflow-grey: #bcbbbb
+$github-black: #9ba6b0
+$github-black-hover: #657380
+$github-white: $white
+$placeholder-grey: #595959
+$button-hover: #b31100
+$circle-logo-backround: #4f456d
+$circle-logo-border: $green
+$dark-gray: #3e6574
+$dark-red: #c4000f
+$dark-salmon: #823830
+$disabled-gray: #595959
+$green-tint: #3f6a74
+$green-tint-end: #37757c
+$grey-blue: #3d6575
+$greyish: #a6a6a6
+$hero-grey: #2b4455
+$hover-red: #800d00
+$light-blue-grey: #2f4551
+$light-blue: #1a6661
+$light-gray: #181818
+$light-orange: #b34d00
+$light-peach: #703710
+$light-red: #800b00
+$lighter-gray: #394147
+$lighter-red2: #7a1106
+$lighter-red: #800b00
+$main-black: #dadada
+$metal-blue: #2b4f54
+$more-gray: #d8d8d8
+$pale-gray: #202020
+$pale-red: #800d00
+$pale-blue: #3a4146
+$pinkish-grey: #404040
+$hover-orange: #801100
+$sand: #533d2c
+$skeleton-background-color: #404040
+$snow: #595959
+$steel-gray: #22272a
+$wh-black: #a6a6a6
+$white-two: #404040
+$pale-blue: #2d4d53
+$sea-blue: #91e3ee
+$tag-bg-orange: #4D2000
+$tag-orange: #ff964d
+$tag-bg-blue: #2d4c53
+$tag-col-blue: #2d5349
+$tag-bg-blue2: #1f3d61
+$tag-col-blue2: #1b3b64
+$tag-green: #ebf5eb
+$tag-bg-green: #3c773c
+
+$hired-color: #7ecea8
+$hired-background: #196634
+$rejected-color: #d87474
+$rejected-background: #7e0202
+$pending-color: #6f4210
+$pending-background: #ab9d07
+
+$wh-background: #282828
+$steel-gray-text: #9ca8b0
+$light-gray-text: #abc3d3
+$disabled-gray-text: $lighter-gray
+
+$steel-gray-with-alpha: rgba(131, 172, 200, 0.6)
+
+$hover-colors: $light-red, $light-orange, $red, $metal-blue, $light-peach, $grey-blue, $light-blue-grey, $steel-gray
+
+@import "wh.sass"

--- a/client/styles/wh-light.sass
+++ b/client/styles/wh-light.sass
@@ -1,0 +1,78 @@
+@import "../vendor/bulma/sass/utilities/initial-variables"
+
+$twitter-blue: #1da1f2
+$twitter-blue-hover: #4db5f5
+$twitter-grey: #bcbbbb
+$stackoverflow-grey: #bcbbbb
+$github-black: #24292e
+$github-black-hover: #444d56
+$github-white: white
+$placeholder-grey: #adadad
+$button-hover: #ff9f95
+$circle-logo-backround: #f5f4f8
+$circle-logo-border: $green
+$dark-gray: #98BAC8
+$dark-red: #c4000f
+$dark-salmon: #bf5d52
+$disabled-gray: #e8e8e8
+$green: #80b5bc
+$green-tint: #dae8eb
+$green-tint-end: #b7dbdf
+$grey-blue: #97bac9
+$grey-darker: #434E55
+$grey: #dedede
+$greyish: #adadad
+$hero-grey: #f5f8fa
+$hover-red: #ffb1a8
+$light-blue-grey: #c4d4dd
+$light-blue: #d4f4f2
+$light-gray: #e6edf2
+$light-orange: #ffae71
+$light-peach: #f9e3d4
+$light-red: #ffdedb
+$lighter-gray: #e5e8ea
+$lighter-red2: #feecea
+$lighter-red: #ffe9e7
+$main-black: #4a4a4a
+$metal-blue: #7eb5bd
+$more-gray: #d8d8d8
+$pale-gray: #f4f5f8
+$pale-red: #ffd4cf
+$pale-blue: #e2e5e7
+$pinkish-grey: #bcbcbc
+$red: #ff7c6e
+$hover-orange: #ff9f90
+$sand: #f7f3f0
+$skeleton-background-color: #ddd
+$snow: #fffaf9
+$steel-gray: #6E7F89
+$wh-black: #171717
+$white-two: #dbdbdb
+$pale-blue: #f2f7f8
+$sea-blue: #136d79
+$tag-bg-orange: #fff1e7
+$tag-orange: #FF913E
+$tag-bg-blue: #e7f0f2
+$tag-col-blue: #5197B4
+$tag-bg-blue2: #ecf2f9
+$tag-col-blue2: #437fcc
+$tag-bg-green: #ebf5eb
+$tag-green: #5EA62E
+
+$hired-color: #276749
+$hired-background: #9AE6B4
+$rejected-color: #9B2C2C
+$rejected-background: #FEB2B2
+$pending-color: #975A16
+$pending-background: #FAF089
+
+$wh-background: #e6edf2
+$steel-gray-text: $steel-gray
+$light-gray-text: $light-gray
+$disabled-gray-text: $light-gray
+
+$steel-gray-with-alpha: rgba(37, 65, 84, 0.6)
+
+$hover-colors: $light-red, $light-orange, $red, $metal-blue, $light-peach, $grey-blue, $light-blue-grey, $steel-gray
+
+@import "wh.sass"

--- a/client/styles/wh-light.sass
+++ b/client/styles/wh-light.sass
@@ -68,8 +68,12 @@ $pending-background: #FAF089
 
 $wh-background: #e6edf2
 $steel-gray-text: $steel-gray
-$light-gray-text: $light-gray
 $disabled-gray-text: $light-gray
+$section-white: $white
+$app-background: $pale-gray
+$tag-background: $lighter-red
+$tag-text: $red
+$footer-text: $white
 
 $steel-gray-with-alpha: rgba(37, 65, 84, 0.6)
 

--- a/client/vendor/bulma-switch/sass/index.sass
+++ b/client/vendor/bulma-switch/sass/index.sass
@@ -1,0 +1,202 @@
+$switch-background: $grey-light !default
+$switch-border: .1rem solid transparent !default
+$switch-background-active: $primary !default
+$switch-radius: $radius !default
+$switch-paddle-background: $white !default
+$switch-paddle-background-active: $primary !default
+$switch-paddle-offset: 0.25rem !default
+$switch-paddle-transition: all 0.25s ease-out !default
+$switch-focus: 1px dotted $grey-light !default
+
+=switch-size($size)
+	$switch-height: $size * 1.5
+	$switch-width: $switch-height * 2
+	$paddle-height: $switch-height - ($switch-paddle-offset * 2)
+	$paddle-width: $switch-height - ($switch-paddle-offset * 2)
+	$paddle-active-offest: $switch-width - $paddle-width - ($switch-paddle-offset * 1.5)
+
+	+ label
+		position: relative
+		display: inline-flex
+		align-items: center
+		justify-content: flex-start
+		font-size: $size
+		height: $control-height
+		line-height: $control-line-height
+		padding-left: $switch-width + .5
+		padding-top: .2rem
+		cursor: pointer
+
+		&::before,
+		&:before
+			position: absolute
+			display: block
+			top: calc( 50% - #{$switch-height} / 2 )
+			left: 0
+			width: $switch-width
+			height: $switch-height
+			border: $switch-border
+			border-radius: $switch-radius
+			background: $switch-background
+			content: ''
+
+		&::after,
+		&:after
+			display: block
+			position: absolute
+			top: calc( 50% - #{$paddle-height} / 2 )
+			left: $switch-paddle-offset
+			width: $paddle-width
+			height: $paddle-height
+			transform: translate3d(0, 0, 0)
+			border-radius: $switch-radius
+			background: $switch-paddle-background
+			transition: $switch-paddle-transition
+			content: ''
+
+	&.is-rtl
+		+ label
+			padding-left: 0
+			padding-right: $switch-width + .5
+			&::before,
+			&:before
+				left: auto
+				right: 0
+			&::after,
+			&:after
+				left: auto
+				right: $paddle-active-offest
+
+	&:checked
+		+ label
+			&::before,
+			&:before
+				background: $switch-background-active
+			&::after
+				left: $paddle-active-offest
+		&.is-rtl
+			+ label
+				&::after,
+				&:after
+					left: auto
+					right: $switch-paddle-offset
+
+	&.is-outlined
+		+ label
+			&::before,
+			&:before
+				background-color: transparent
+				border-color: $switch-background
+			&::after,
+			&:after
+				background: $switch-background
+		&:checked
+			+ label
+				&::before,
+				&:before
+					background-color: transparent
+					border-color: $switch-background-active
+				&::after,
+				&:after
+					background: $switch-paddle-background-active
+
+	&.is-thin
+		+ label
+			&::before,
+			&:before
+				top: $switch-height / 2.75
+				height: $switch-height / 4
+			&::after,
+			&:after
+				box-shadow: 0px 0px 3px $grey
+
+	&.is-rounded
+		+ label
+			&::before,
+			&:before
+				border-radius: $radius-large * 4
+			&::after,
+			&:after
+				border-radius: 50%
+
+
+.switch[type="checkbox"]
+	outline: 0
+	user-select: none
+	display: inline-block
+	position: absolute
+	opacity: 0
+
+	&:focus
+		+ label
+			&::before,
+			&:before,
+			&::after,
+			&:after
+				outline: $switch-focus
+
+	&[disabled]
+		cursor: not-allowed
+		+ label
+			opacity: 0.5
+			&::before,
+			&:before
+				opacity: 0.5
+			&::after,
+			&:after
+				opacity: 0.5
+			&:hover
+				cursor: not-allowed
+
+	+switch-size($size-normal)
+	&.is-small
+		+switch-size($size-small)
+	&.is-medium
+		+switch-size($size-medium)
+	&.is-large
+		+switch-size($size-large)
+
+	@each $name, $pair in $colors
+		$color: nth($pair, 1)
+		$color-invert: nth($pair, 2)
+		&.is-#{$name}
+			&:checked
+				+ label
+					&::before,
+					&:before
+						background: $color
+			&.is-outlined
+				&:checked
+					+ label
+						&::before,
+						&:before
+							background-color: transparent
+							border-color: $color !important
+						&::after,
+						&:after
+							background: $color
+			&.is-thin
+				&.is-outlined
+					+ label
+						&::after,
+						&:after
+							box-shadow: none
+		&.is-unchecked-#{$name}
+			+ label
+				&::before,
+				&:before
+					background: $color
+			&.is-outlined
+				+ label
+					&::before,
+					&:before
+						background-color: transparent
+						border-color: $color !important
+					&::after,
+					&:after
+						background: $color
+
+.field-body
+	.switch[type="checkbox"]
+		+ label
+			margin-top: .375em

--- a/server/src/wh/server.clj
+++ b/server/src/wh/server.clj
@@ -86,7 +86,7 @@
                   [:div#app-js] (html/content {:tag :script, :attrs {:type "text/javascript", :src "/js/wh.js"}})
                   [:div#tracking-popup-container] (html/content (->html (tracking/popup)))
                   [:div#auth-popup-container] (html/content (->html (auth/popup (verticals/config (:wh.db/vertical app-db) :platform-name))))
-                  [:style#main-style] (constantly {:tag :link, :attrs {:rel "stylesheet", :type "text/css", :href "/wh.css"}})
+                  [:style#main-style] (constantly {:tag :link, :attrs {:id "main-style" :rel "stylesheet", :type "text/css", :href "/wh-light.css"}})
                   [:link.external-css]  (html/clone-for [filename (external-css)]
                                                         (html/set-attr :href filename
                                                                        :rel "stylesheet"


### PR DESCRIPTION
Fixes #31

I tried to solve it first with css classes/variables. Unfortunately bulma cannot handle css variables ( it generates inverted/light/dark colors during sass compilation from rgb values ) so I had to go with two separate css files.
The color values were extracted from wh.sass and placed to wh-light.sass and wh-dark.sass  and the remaining part of wh.sass is inlcuded at the bottom of these files.
In wh-dark.sass simple colors had to be defined before bulma/initial-variables import to be able to skin bulma.
Primary and primary-invert colors had to be defined for bulma-switch.
wh-white was removed because it was identical to white.
Quill background colors and webkit-autofill defaults had to be overridden.

First I tried to check the localstorage state right in index.html's head with a script and load/replace/append the needed css in a lot of different ways but sometimes the styleless content showed up on reloads so I realized I have to wait for the new style to load and then remove the old style. So I moved all code to clojurescript into common-sources/wh/pages/utils.cljc. 

Added bulma-switch sass to vendor, created a "settings" section with a toggle switch in logged_in/profile/views cljs, added darkmode-enabled? property to profile db and listener in subs, added toggle-dark-mode event to events.

I tested it in chrome in desktop/mobile views, tried to go into every corner possible with candidate, admin and company accounts but someone who knows the site better should double-check it with the live database. It looks good and the light theme shows up only for a millisec on reload. The perfect solution would be theme switching with css classes and variables but sass and bulma don't support them. 