### PR TITLE
Update _chatbot.sass

### DIFF
--- a/client/legacy-styles/_chatbot.sass
+++ b/client/legacy-styles/_chatbot.sass
@@ -10,6 +10,7 @@
     bottom: 15px
     width: 300px
     height: 500px
+    max-height: 80vh
     border-radius: $radius $radius 0 $radius
     right: calc(50% - 565px) !important
     @media screen and (max-width: 1366px)


### PR DESCRIPTION
This addition prevents the close icon on the id="chatbot" from being hidden (and thus the entire div properly shows) due to the div height of 500px being greater than the window height on some desktop browsers.