### PR TITLE
Update footer.cljc

### DIFF
--- a/common/src/wh/components/footer.cljc
+++ b/common/src/wh/components/footer.cljc
@@ -130,7 +130,7 @@
    {:logo "twitter-circle"
     :href (str "https://twitter.com/" (verticals/config vertical :twitter))}
    {:logo "facebook-circle"
-    :href "https://business.facebook.com/weareworkshub/"}
+    :href "https://facebook.com/weareworkshub/"}
    {:logo "github"
     :href "https://github.com/workshub"}])
 


### PR DESCRIPTION
Likely no definite need to direct users to business subdomain of facebook.com. Further, any future use of a 'Facebook pixel' may not correctly identify users who are logged into business.facebook.com with a business account.