### PR TITLE
Add catchall 404 response for unmatched routes

### DIFF
--- a/server/src/wh/server.clj
+++ b/server/src/wh/server.clj
@@ -115,10 +115,14 @@
       wh-index-template
       html-response))
 
+(defn wrap-catchall [handler]
+  (fn [request] (or (handler request) (resp/not-found "The requested resource was not found."))))
+
 (def handler
   (-> (bidi-ring/make-handler routes/routes (constantly index-handler))
       (wrap-resource "public")
-      (wrap-content-type)))
+      (wrap-content-type)
+      (wrap-catchall)))
 
 (defonce server
   (atom nil))


### PR DESCRIPTION
Fix for #47 

I added a safeguard that prevents the root handler to return `nil`. In the case no configured routes match, a plain 404 response is returned.

More specific not-found responses for certain routes can still be configured in the routes table, this is just the last fallback handler.