### PR TITLE
fix: 'View all' jobs link on Issue page

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ npm run dev
 
 Now point your browser to: http://localhost:3449 and you should see the WorksHub UI.
 
-(If you're curious, we're using shadow-cljs to watch and compile our frontend. Fell free to run shadow server by yourself and access shadow-cljs Inspect. We have globally available `tap>` in our code. It also means that you can freely install any npm packages with `npm install` and require these in code. Go crazy!)
+(If you're curious, we're using shadow-cljs to watch and compile our frontend. Feel free to run shadow server by yourself and access shadow-cljs Inspect. We have globally available `tap>` in our code. It also means that you can freely install any npm packages with `npm install` and require these in code. Go crazy!)
 
 Now, after a refresh, you should see the landing page.
 

--- a/common/src/wh/graphql/fragments.cljc
+++ b/common/src/wh/graphql/fragments.cljc
@@ -38,7 +38,7 @@
    [:compensation [:amount :currency]]
    [:contributors [:id :name [:other_urls [:url]] [:github_info [:login]]]]
    [:repo [:owner :name :description :primary_language [:community [:readme_url :contributing_url]]]]
-   [:company [:id :name :logo]]
+   [:company [:id :name :logo :slug]]
    [:author [:login :name]]
    [:labels [:name]]])
 


### PR DESCRIPTION
Hi !

While using the app, I realised that on the `/issue/<UUID>` page, the **View all** link for **Jobs with this company** doesn't work. 

This is what gets printed on the console:

```
Unable to construct link: {:params {:slug nil}, :handler :company-jobs}
```

The re-frame sub is ok, but the GraphQL query is not I think.